### PR TITLE
feat: add slide animation to right sidebar

### DIFF
--- a/src/app/pages/TaskDetail.tsx
+++ b/src/app/pages/TaskDetail.tsx
@@ -878,28 +878,31 @@ function TaskDetailContent() {
           )}
 
           {/* Divider between preview/chat and sidebar */}
-          {isRightSidebarVisible && (
-            <div className="bg-border/50 w-px shrink-0" />
-          )}
+          <div
+            className={cn(
+              'bg-border/50 shrink-0 transition-all duration-300',
+              isRightSidebarVisible ? 'w-px' : 'w-0'
+            )}
+          />
 
           {/* Right Panel - Progress, Artifacts, Context (fixed width) */}
-          {isRightSidebarVisible && (
-            <div
-              className="bg-background flex shrink-0 flex-col overflow-hidden rounded-r-2xl"
-              style={{ width: '280px', minWidth: '240px', maxWidth: '320px' }}
-            >
-              <RightSidebar
-                messages={messages}
-                isRunning={isRunning}
-                artifacts={artifacts}
-                selectedArtifact={selectedArtifact}
-                onSelectArtifact={handleSelectArtifact}
-                workingDir={workingDir}
-                sessionFolder={sessionFolder || undefined}
-                filesVersion={filesVersion}
-              />
-            </div>
-          )}
+          <div
+            className={cn(
+              'bg-background flex shrink-0 flex-col overflow-hidden rounded-r-2xl transition-all duration-300',
+              isRightSidebarVisible ? 'w-[280px]' : 'w-0'
+            )}
+          >
+            <RightSidebar
+              messages={messages}
+              isRunning={isRunning}
+              artifacts={artifacts}
+              selectedArtifact={selectedArtifact}
+              onSelectArtifact={handleSelectArtifact}
+              workingDir={workingDir}
+              sessionFolder={sessionFolder || undefined}
+              filesVersion={filesVersion}
+            />
+          </div>
         </div>
       </div>
     </ToolSelectionContext.Provider>


### PR DESCRIPTION
## Summary

Add smooth slide animation to the right sidebar in TaskDetail, matching the left sidebar behavior.

## Changes

- Replace conditional rendering with CSS width transition (`w-[280px]` ↔ `w-0`)
- Add `transition-all duration-300` for smooth 300ms animation
- Apply same animation to the divider

## Trade-off

This change removes conditional rendering, which means:

**Pros:**
- Simple implementation with pure CSS transitions
- Consistent with left sidebar animation pattern
- Preserves component state (scroll position, tab selection) during toggle

**Cons:**
- Component remains in DOM when hidden (width: 0)
- Internal useEffects continue to run when sidebar is collapsed

**Why this approach:**
The RightSidebar's useEffects are dependency-triggered (not polling), so the performance impact is minimal. The simplicity of CSS-only animation outweighs the cost of keeping the component mounted.

If conditional unmounting is required later, a delayed-unmount pattern can be implemented.