### PR TITLE
feat: add collapse animation to right sidebar sections

### DIFF
--- a/src/components/task/RightSidebar.tsx
+++ b/src/components/task/RightSidebar.tsx
@@ -698,7 +698,16 @@ function CollapsibleSection({
           )}
         </span>
       </button>
-      {isExpanded && <div className="px-4 pb-3">{children}</div>}
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-300',
+          isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="px-4 pb-3">{children}</div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Add smooth collapse/expand animation to CollapsibleSection component in the right sidebar.

## Changes

Use CSS Grid `grid-template-rows` technique for height animation:

```tsx
<div className={cn(
  'grid transition-[grid-template-rows] duration-300',
  isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
)}>
  <div className="overflow-hidden">
    {children}
  </div>
</div>
```

## Why this approach

- Pure CSS, no JavaScript height calculation
- Works with dynamic content (`height: auto`)
- 300ms duration matches other sidebar animations
- Minimal code change (10 lines added)