### PR TITLE
fix: add missing ANTHROPIC_BASE_URL and ANTHROPIC_MODEL env vars in createAgentFromEnv

### DIFF
--- a/src-api/src/core/agent/index.ts
+++ b/src-api/src/core/agent/index.ts
@@ -201,7 +201,8 @@ export function createAgentFromEnv(overrides?: Partial<AgentConfig>): IAgent {
   return createAgent({
     provider,
     apiKey: process.env.ANTHROPIC_API_KEY,
-    model: process.env.AGENT_MODEL,
+    baseUrl: process.env.ANTHROPIC_BASE_URL,
+    model: process.env.ANTHROPIC_MODEL || process.env.AGENT_MODEL,
     workDir: process.env.AGENT_WORK_DIR || DEFAULT_WORK_DIR,
     ...overrides,
   });


### PR DESCRIPTION
## Summary

- Add `ANTHROPIC_BASE_URL` environment variable support in `createAgentFromEnv()`
- Add `ANTHROPIC_MODEL` as primary model config option (with `AGENT_MODEL` as fallback)

## Problem

When using a custom API proxy (e.g., OpenRouter or other third-party services), the `createAgentFromEnv()` function was not reading `ANTHROPIC_BASE_URL` from environment variables. This caused all requests to be sent to the default Anthropic API endpoint, resulting in authentication failures.

##  Test Plan
[x] Set ANTHROPIC_BASE_URL to a custom proxy endpoint
[x] Verify agent requests are sent to the correct base URL
[x] Verify ANTHROPIC_MODEL takes precedence over AGENT_MODEL
