### PR TITLE
fix: add Rust toolchain check before Tauri dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ver": "./scripts/version.sh",
     "dev": "vite",
     "dev:api": "pnpm --filter workany-api dev",
+    "predev:app": "node scripts/check-rust.js",
     "dev:app": "pnpm tauri dev",
     "dev:web": "pnpm dev",
     "dev:all": "concurrently \"pnpm dev:api\" \"pnpm dev:app\"",

--- a/scripts/check-rust.js
+++ b/scripts/check-rust.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * Pre-flight check for Rust toolchain
+ * Required for Tauri desktop app development
+ */
+
+import { execSync } from 'child_process';
+
+function checkCommand(cmd, name) {
+  try {
+    execSync(`${cmd} --version`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const hasRustup = checkCommand('rustup', 'rustup');
+const hasCargo = checkCommand('cargo', 'cargo');
+
+if (!hasCargo) {
+  console.error(`
+\x1b[33m╔════════════════════════════════════════════════════════════════════════╗
+║                                                                        ║
+║  ⚠️  Rust toolchain not found                                           ║
+║                                                                        ║
+║  Tauri requires Rust to build the desktop app.                         ║
+║                                                                        ║
+║  Install Rust by running:                                              ║
+║                                                                        ║
+║    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh      ║
+║                                                                        ║
+║  After installation, restart your terminal and try again.              ║
+║                                                                        ║
+║  For more info: https://www.rust-lang.org/tools/install                ║
+║                                                                        ║
+╚════════════════════════════════════════════════════════════════════════╝\x1b[0m
+`);
+  process.exit(1);
+}
+
+// Optional: Check rustup for toolchain management
+if (!hasRustup) {
+  console.warn('\x1b[33m[warn] rustup not found. Consider installing via rustup for easier toolchain management.\x1b[0m');
+}
+
+console.log('\x1b[32m✓ Rust toolchain detected\x1b[0m');


### PR DESCRIPTION
Closes #5
## Summary
Add a Rust toolchain preflight check before starting Tauri dev to avoid failures when Rust isn’t installed.

## Changes
- Add `scripts/check-rust.js` to detect `cargo` (error with install instructions if missing) and warn if `rustup` is
not present
- Wire the check into `predev:app` so it runs before `pnpm dev:app`

## Testing
- Not run (not requested)

## Notes
- Only affects the `pnpm dev:app` startup path; other commands are unchanged

Closes #5