### PR TITLE
feat: add SiliconFlow CN and SiliconFlow providers

### DIFF
--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -301,6 +301,47 @@ export const defaultProviders: AIProvider[] = [
     apiKeyUrl: 'https://docs.ollama.com/integrations/claude-code',
     canDelete: true,
   },
+  {
+    id: 'siliconflow-cn',
+    name: 'SiliconFlow CN',
+    apiKey: '',
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    enabled: true,
+    models: [
+      'Pro/deepseek-ai/DeepSeek-V3.1-Terminus',
+      'Pro/deepseek-ai/DeepSeek-V3.2',
+      'Pro/moonshotai/Kimi-K2-Instruct-0905',
+      'Pro/moonshotai/Kimi-K2-Thinking',
+      'Pro/MiniMaxAI/MiniMax-M2.1',
+      'Pro/zai-org/GLM-4.7',
+      'deepseek-ai/DeepSeek-V3.1-Terminus',
+      'deepseek-ai/DeepSeek-V3.2',
+      'moonshotai/Kimi-K2-Instruct-0905',
+      'moonshotai/Kimi-K2-Thinking'
+    ],
+    icon: 'S',
+    apiKeyUrl: 'https://cloud.siliconflow.cn/me/account/ak',
+    canDelete: true,
+  },
+  {
+    id: 'siliconflow',
+    name: 'SiliconFlow',
+    apiKey: '',
+    baseUrl: 'https://api.siliconflow.com/v1',
+    enabled: true,
+    models: [
+      'deepseek-ai/DeepSeek-V3.1-Terminus',
+      'deepseek-ai/DeepSeek-V3.2',
+      'moonshotai/Kimi-K2-Instruct-0905',
+      'moonshotai/Kimi-K2-Thinking',
+      'MiniMaxAI/MiniMax-M2.1',
+      'openai/gpt-oss-120b',
+      'zai-org/GLM-4.7',      
+    ],
+    icon: 'S',
+    apiKeyUrl: 'https://cloud.siliconflow.com/me/account/ak',
+    canDelete: true,
+  },
 ];
 
 // Default provider IDs that cannot be deleted (derived from defaultProviders)
@@ -335,6 +376,25 @@ export const customProviderModels: Record<string, string[]> = {
   moonshot: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
   zhipu: ['glm-4-plus', 'glm-4-flash', 'glm-4-long'],
   qwen: ['qwen-max', 'qwen-plus', 'qwen-turbo'],
+  siliconflow: [
+    'deepseek-ai/DeepSeek-V3',
+    'deepseek-ai/DeepSeek-V3.1-Terminus',
+    'deepseek-ai/DeepSeek-V3.2',
+    'deepseek-ai/DeepSeek-R1',
+    'Pro/deepseek-ai/DeepSeek-V3',
+    'Pro/deepseek-ai/DeepSeek-V3.1-Terminus',
+    'Pro/deepseek-ai/DeepSeek-V3.2',
+    'Pro/deepseek-ai/DeepSeek-R1',
+    'Qwen/Qwen3-235B-A22B-Instruct-2507',
+    'Qwen/Qwen3-235B-A22B-Thinking-2507',
+    'Qwen/Qwen3-Coder-480B-A35B-Instruct',
+    'moonshotai/Kimi-K2-Instruct-0905',
+    'moonshotai/Kimi-K2-Thinking',
+    'Pro/moonshotai/Kimi-K2-Instruct-0905',
+    'Pro/moonshotai/Kimi-K2-Thinking',
+    'Pro/MiniMaxAI/MiniMax-M2.1',
+    'Pro/zai-org/GLM-4.7',
+  ],
 };
 
 // Default settings


### PR DESCRIPTION
- Add SiliconFlow CN provider with Pro models for China region
- Add SiliconFlow provider for international region
- Configure region-specific API endpoints and key URLs
- Add customProviderModels mapping with 16 model suggestions
- Support models: DeepSeek V3/V3.1/V3.2/R1, Qwen3, Kimi K2, MiniMax, GLM-4.7