### PR TITLE
fix: use tool error flags consistently

### DIFF
--- a/src-api/src/extensions/agent/claude/index.ts
+++ b/src-api/src/extensions/agent/claude/index.ts
@@ -1638,17 +1638,26 @@ If you need to create any files during planning, use this directory.
     if (msg.type === 'user' && msg.message?.content) {
       for (const block of msg.message.content as Record<string, unknown>[]) {
         if ('type' in block && block.type === 'tool_result') {
+          const toolUseIdSnake = (block as { tool_use_id?: unknown })
+            .tool_use_id;
+          const toolUseIdCamel = (block as { toolUseId?: unknown }).toolUseId;
+          const isErrorSnake = (block as { is_error?: unknown }).is_error;
+          const isErrorCamel = (block as { isError?: unknown }).isError;
+          const toolUseId = toolUseIdSnake ?? toolUseIdCamel;
+          const rawIsError = isErrorSnake ?? isErrorCamel;
+          const isError = typeof rawIsError === 'boolean' ? rawIsError : false;
+
           console.log(
-            `[Claude ${sessionId}] Tool result for: ${block.tool_use_id}`
+            `[Claude ${sessionId}] Tool result for: ${String(toolUseId)}`
           );
           yield {
             type: 'tool_result',
-            toolUseId: block.tool_use_id as string,
+            toolUseId: (toolUseId ?? '') as string,
             output:
               typeof block.content === 'string'
                 ? block.content
                 : JSON.stringify(block.content),
-            isError: (block.is_error as boolean) || false,
+            isError,
           };
         }
       }

--- a/src/components/task/ToolExecutionItem.tsx
+++ b/src/components/task/ToolExecutionItem.tsx
@@ -130,10 +130,7 @@ function getResultInfo(
     output = toolUseErrorMatch[1].trim();
   }
 
-  const isError =
-    result.isError ||
-    output.toLowerCase().includes('error') ||
-    toolUseErrorMatch;
+  const isError = !!result.isError;
   const isWarning = isExpectedWarning(toolName, output);
 
   if (isError) {
@@ -373,9 +370,7 @@ export function ToolExecutionItem({
 
   // Check status
   const isRunning = isLast && !result;
-  const hasError =
-    result?.isError ||
-    (result?.output || result?.content || '').toLowerCase().includes('error');
+  const hasError = !!result?.isError;
   // If it's a warning (expected non-fatal), don't treat as error
   const isActualError = hasError && !isWarning;
   const isCompleted = !isRunning && !isActualError && result;


### PR DESCRIPTION
## Summary
- Frontend now relies solely on `isError` for tool failure state to avoid false positives from string matching
- Backend maps both `tool_use_id`/`toolUseId` and `is_error`/`isError` into `isError`

## Testing
All Pass!

Fixes #10