### PR TITLE
feat: add Kimi CLI agent support

### DIFF
--- a/src-api/src/config/constants.ts
+++ b/src-api/src/config/constants.ts
@@ -79,6 +79,8 @@ export const DEFAULT_AGENT_PROVIDER = 'claude';
 /** Default agent model */
 export const DEFAULT_AGENT_MODEL = 'claude-sonnet-4-20250514';
 
+export const DEFAULT_KIMI_MODEL = 'kimi-for-coding';
+
 // ============================================================================
 // Timeouts and Limits
 // ============================================================================

--- a/src-api/src/core/agent/index.ts
+++ b/src-api/src/core/agent/index.ts
@@ -6,6 +6,7 @@ import { DEFAULT_AGENT_PROVIDER, DEFAULT_WORK_DIR } from '@/config/constants';
 import { claudePlugin } from '@/extensions/agent/claude';
 import { codexPlugin } from '@/extensions/agent/codex';
 import { deepagentsPlugin } from '@/extensions/agent/deepagents';
+import { kimiPlugin } from '@/extensions/agent/kimi';
 
 /**
  * Agent SDK Abstraction Layer
@@ -89,6 +90,11 @@ export {
   deepagentsPlugin,
 } from '@/extensions/agent/deepagents';
 
+export {
+  KimiAgent,
+  createKimiAgent,
+  kimiPlugin,
+} from '@/extensions/agent/kimi';
 /**
  * All built-in agent plugins
  */
@@ -96,6 +102,7 @@ export const builtinAgentPlugins: AgentPlugin[] = [
   claudePlugin,
   codexPlugin,
   deepagentsPlugin,
+  kimiPlugin,
 ];
 
 /**

--- a/src-api/src/core/agent/plugin.ts
+++ b/src-api/src/core/agent/plugin.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentConfig, IAgent } from '@/core/agent/types';
-import { DEFAULT_AGENT_MODEL, DEFAULT_WORK_DIR } from '@/config/constants';
+import { DEFAULT_AGENT_MODEL, DEFAULT_WORK_DIR, DEFAULT_KIMI_MODEL } from '@/config/constants';
 import type { ProviderMetadata } from '@/shared/provider/types';
 
 // ============================================================================
@@ -178,6 +178,31 @@ export const DEEPAGENTS_CONFIG_SCHEMA = {
   },
 };
 
+export const KIMI_CONFIG_SCHEMA = {
+  type: 'object',
+  properties: {
+    apiKey: {
+      type: 'string',
+      description: 'Kimi Code API key (optional if using OAuth)',
+    },
+    baseUrl: {
+      type: 'string',
+      description: 'Kimi Code API base URL',
+      default: 'https://api.kimi.com/coding/v1',
+    },
+    model: {
+      type: 'string',
+      default: DEFAULT_KIMI_MODEL,
+      description: 'Kimi model to use',
+    },
+    workDir: {
+      type: 'string',
+      default: DEFAULT_WORK_DIR,
+      description: 'Working directory for file operations',
+    },
+  },
+};
+
 // ============================================================================
 // Built-in Plugin Metadata
 // ============================================================================
@@ -240,4 +265,21 @@ export const DEEPAGENTS_METADATA: AgentProviderMetadata = {
   supportsStreaming: true,
   supportsSandbox: false,
   tags: ['langgraph', 'deepagents', 'multi-provider'],
+};
+ 
+
+/**   
+ * Metadata for built-in Kimi agent
+ */
+export const KIMI_METADATA: AgentProviderMetadata = {
+  type: 'kimi',
+  name: 'Kimi Agent',
+  version: '1.0.0',
+  description:
+    'Kimi Agent SDK integration. Uses Kimi models through the kimi command-line tool.',
+  configSchema: KIMI_CONFIG_SCHEMA,
+  builtin: true,
+  supportsPlan: true,
+  supportsStreaming: true,
+  supportsSandbox: true,
 };

--- a/src-api/src/core/agent/types.ts
+++ b/src-api/src/core/agent/types.ts
@@ -89,7 +89,7 @@ export interface PlanStep {
 // Agent Configuration
 // ============================================================================
 
-export type AgentProvider = 'claude' | 'codex' | 'deepagents' | 'custom';
+export type AgentProvider = 'claude' | 'codex' | 'deepagents' | 'kimi' | 'custom';
 
 export interface AgentConfig {
   /** Agent provider to use */
@@ -284,7 +284,7 @@ export interface AgentRequest {
   workDir?: string; // Working directory for session outputs
   taskId?: string; // Task ID for session folder
   // Provider selection (optional, defaults to env config)
-  provider?: 'claude' | 'deepagents';
+  provider?: 'claude' | 'deepagents' | 'kimi';
   // Custom model configuration
   modelConfig?: ModelConfig;
   // Sandbox configuration for isolated execution

--- a/src-api/src/extensions/agent/kimi/index.ts
+++ b/src-api/src/extensions/agent/kimi/index.ts
@@ -1,0 +1,722 @@
+/**
+ * Kimi CLI Agent Implementation
+ *
+ * Implementation of the IAgent interface using kimi-cli
+ * Supports streaming responses, planning, and tool execution
+ */
+
+import { spawn } from 'child_process';
+import { mkdir, writeFile } from 'fs/promises';
+import { homedir, platform } from 'os';
+import { join } from 'path';
+
+import {
+  BaseAgent,
+  formatPlanForExecution,
+  getWorkspaceInstruction,
+  parsePlanFromResponse,
+  parsePlanningResponse,
+  PLANNING_INSTRUCTION,
+  type SandboxOptions,
+} from '@/core/agent/base';
+import { KIMI_METADATA, defineAgentPlugin } from '@/core/agent/plugin';
+import type { AgentPlugin } from '@/core/agent/plugin';
+import type {
+  AgentConfig,
+  AgentMessage,
+  AgentOptions,
+  AgentProvider,
+  ConversationMessage,
+  ExecuteOptions,
+  ImageAttachment,
+  McpConfig,
+  PlanOptions,
+  SkillsConfig,
+} from '@/core/agent/types';
+import {
+  DEFAULT_API_HOST,
+  DEFAULT_API_PORT,
+  DEFAULT_WORK_DIR,
+} from '@/config/constants';
+import { loadMcpServers, type McpServerConfig } from '@/shared/mcp/loader';
+import { createLogger, LOG_FILE_PATH } from '@/shared/utils/logger';
+
+import { ensureKimiCli, getKimiCliPath, isPackagedApp } from './utils';
+
+const logger = createLogger('KimiAgent');
+
+// API port configuration
+const isDev = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
+const API_PORT =
+  process.env.PORT || (isDev ? '2026' : String(DEFAULT_API_PORT));
+const SANDBOX_API_URL =
+  process.env.SANDBOX_API_URL || `http://${DEFAULT_API_HOST}:${API_PORT}`;
+
+/**
+ * Expand ~ to home directory and normalize path separators
+ */
+function expandPath(inputPath: string): string {
+  let result = inputPath;
+
+  // Expand ~ to home directory
+  if (result.startsWith('~')) {
+    result = join(homedir(), result.slice(1));
+  }
+
+  // Normalize path separators for current platform
+  if (platform() === 'win32') {
+    result = result.replace(/\//g, '\\');
+  }
+
+  return result;
+}
+
+/**
+ * Generate a fallback slug from prompt for session directory name
+ */
+function generateFallbackSlug(prompt: string, taskId: string): string {
+  let slug = prompt
+    .toLowerCase()
+    // Remove Chinese and keep only alphanumeric
+    .replace(/[\u4e00-\u9fff]/g, '')
+    .replace(/[^\w\s-]/g, ' ')
+    .replace(/\s+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50)
+    .replace(/-+$/, '');
+
+  if (!slug || slug.length < 3) {
+    slug = 'task';
+  }
+
+  const suffix = taskId.slice(-6);
+  return `${slug}-${suffix}`;
+}
+
+/**
+ * Get or create session working directory
+ */
+function getSessionWorkDir(
+  workDir: string = DEFAULT_WORK_DIR,
+  prompt?: string,
+  taskId?: string
+): string {
+  logger.info('[Kimi] getSessionWorkDir called with:', {
+    workDir,
+    prompt: prompt?.slice(0, 50),
+    taskId,
+  });
+
+  const expandedPath = expandPath(workDir);
+  logger.info('[Kimi] Expanded path:', expandedPath);
+
+  // Check if the workDir is already a session folder path from frontend
+  const hasSessionsPath = expandedPath.includes('/sessions/') || expandedPath.includes('\\sessions\\');
+  const endsWithSessions = expandedPath.endsWith('/sessions') || expandedPath.endsWith('\\sessions');
+  if (hasSessionsPath && !endsWithSessions) {
+    // Frontend already provided a proper session path, use it directly
+    logger.info('[Kimi] Using frontend-provided session path:', expandedPath);
+    return expandedPath;
+  }
+
+  // No session path provided, generate one (fallback for backward compatibility)
+  const baseDir = expandedPath;
+  const sessionsDir = join(baseDir, 'sessions');
+
+  let folderName: string;
+  if (prompt && taskId) {
+    folderName = generateFallbackSlug(prompt, taskId);
+  } else if (taskId) {
+    folderName = taskId;
+  } else {
+    folderName = `session-${Date.now()}`;
+  }
+
+  const targetDir = join(sessionsDir, folderName);
+  return targetDir;
+}
+
+/**
+ * Ensure a directory exists, creating it if necessary
+ */
+async function ensureDir(dirPath: string): Promise<void> {
+  try {
+    await mkdir(dirPath, { recursive: true });
+  } catch (error) {
+    logger.error('Failed to create directory:', error);
+  }
+}
+
+/**
+ * Save images to disk and return file paths
+ */
+async function saveImagesToDisk(
+  images: ImageAttachment[],
+  workDir: string
+): Promise<string[]> {
+  const savedPaths: string[] = [];
+
+  if (images.length === 0) {
+    return savedPaths;
+  }
+
+  // Only create directory when we actually have images to save
+  await ensureDir(workDir);
+
+  for (let i = 0; i < images.length; i++) {
+    const image = images[i];
+    const ext = image.mimeType.split('/')[1] || 'png';
+    const filename = `image_${Date.now()}_${i}.${ext}`;
+    const filePath = join(workDir, filename);
+
+    try {
+      // Remove data URL prefix if present
+      let base64Data = image.data;
+      if (base64Data.includes(',')) {
+        base64Data = base64Data.split(',')[1];
+      }
+
+      const buffer = Buffer.from(base64Data, 'base64');
+      await writeFile(filePath, buffer);
+      savedPaths.push(filePath);
+      logger.info(`[Kimi] Saved image to: ${filePath}`);
+    } catch (error) {
+      logger.error(`[Kimi] Failed to save image: ${error}`);
+    }
+  }
+
+  return savedPaths;
+}
+
+/**
+ * Default allowed tools for execution
+ */
+const ALLOWED_TOOLS = [
+  'ReadFile',
+  'WriteFile',
+  'Shell',
+  'WebSearch',
+  'WebFetch',
+];
+
+/**
+ * Kimi Agent implementation
+ */
+export class KimiAgent extends BaseAgent {
+  readonly provider: AgentProvider = 'kimi';
+
+  constructor(config: AgentConfig) {
+    super(config);
+    logger.info('[KimiAgent] Created with config:', {
+      provider: config.provider,
+      hasApiKey: !!config.apiKey,
+      baseUrl: config.baseUrl,
+      model: config.model,
+      workDir: config.workDir,
+    });
+  }
+
+  /**
+   * Check if using custom API configuration
+   */
+  private isUsingCustomApi(): boolean {
+    return !!(this.config.baseUrl && this.config.apiKey);
+  }
+
+  /**
+   * Build environment variables for Kimi CLI execution
+   */
+  private buildKimiEnvConfig(): Record<string, string> {
+    const env: Record<string, string | undefined> = { ...process.env };
+
+    // Set Kimi-specific environment variables
+    if (this.config.apiKey) {
+      env.MOONSHOT_API_KEY = this.config.apiKey;
+      logger.info('[KimiAgent] Using custom API key');
+    }
+
+    if (this.config.baseUrl) {
+      env.MOONSHOT_API_BASE = this.config.baseUrl;
+      logger.info('[KimiAgent] Using custom API base URL:', this.config.baseUrl);
+    }
+
+    if (this.config.model) {
+      env.KIMI_MODEL = this.config.model;
+      logger.info('[KimiAgent] Model configured:', this.config.model);
+    }
+
+    // Filter out undefined values
+    const filteredEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(env)) {
+      if (value !== undefined) {
+        filteredEnv[key] = value;
+      }
+    }
+    return filteredEnv;
+  }
+
+  /**
+   * Estimate token count for conversation history
+   */
+  private estimateTokenCount(text: string): number {
+    return Math.ceil(text.length / 4);
+  }
+
+  /**
+   * Format conversation history for inclusion in prompt
+   */
+  private formatConversationHistory(
+    conversation?: ConversationMessage[]
+  ): string {
+    if (!conversation || conversation.length === 0) {
+      return '';
+    }
+
+    const maxHistoryTokens = this.config.providerConfig?.maxHistoryTokens as number || 2000;
+    const minMessagesToKeep = 3;
+
+    const allFormattedMessages = conversation.map((msg) => {
+      const role = msg.role === 'user' ? 'User' : 'Assistant';
+      let messageContent = `${role}: ${msg.content}`;
+
+      if (msg.imagePaths && msg.imagePaths.length > 0) {
+        const imageRefs = msg.imagePaths
+          .map((p, i) => `  - Image ${i + 1}: ${p}`)
+          .join('\n');
+        messageContent += `\n[Attached images in this message:\n${imageRefs}\nUse ReadFile tool to view these images if needed]`;
+      }
+
+      return messageContent;
+    });
+
+    const messageTokens = allFormattedMessages.map(msg => ({
+      content: msg,
+      tokens: this.estimateTokenCount(msg)
+    }));
+
+    let totalTokens = 0;
+    const selectedMessages: string[] = [];
+
+    const startIndex = Math.max(0, messageTokens.length - minMessagesToKeep);
+
+    for (let i = messageTokens.length - 1; i >= startIndex; i--) {
+      const message = messageTokens[i];
+      if (totalTokens + message.tokens <= maxHistoryTokens) {
+        selectedMessages.unshift(message.content);
+        totalTokens += message.tokens;
+      } else {
+        break;
+      }
+    }
+
+    for (let i = startIndex - 1; i >= 0; i--) {
+      const message = messageTokens[i];
+      if (totalTokens + message.tokens <= maxHistoryTokens) {
+        selectedMessages.unshift(message.content);
+        totalTokens += message.tokens;
+      } else {
+        break;
+      }
+    }
+
+    if (selectedMessages.length === 0) {
+      return '';
+    }
+
+    const formattedMessages = selectedMessages.join('\n\n');
+    const truncationNotice = conversation.length > selectedMessages.length
+      ? `\n\n[Note: Conversation history truncated. Showing ${selectedMessages.length} of ${conversation.length} messages to stay within token limits.]`
+      : '';
+
+    logger.info(`[formatConversationHistory] Selected ${selectedMessages.length} of ${conversation.length} messages, estimated ${totalTokens} tokens (limit: ${maxHistoryTokens})`);
+
+    return `## Previous Conversation Context
+The following is the conversation history. Use this context to understand and respond to the current message appropriately.
+
+${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
+  }
+
+  /**
+   * Execute Kimi CLI command and parse streaming JSON output
+   */
+  private async *executeKimiCommand(
+    prompt: string,
+    workDir: string,
+    sessionId: string
+  ): AsyncGenerator<AgentMessage> {
+    const kimiCliPath = await ensureKimiCli();
+    if (!kimiCliPath) {
+      yield {
+        type: 'error',
+        message: '__KIMI_CLI_NOT_FOUND__',
+      };
+      return;
+    }
+
+    const env = this.buildKimiEnvConfig();
+
+    const args = [
+      '--print',
+      '--output-format', 'stream-json',
+      '--work-dir', workDir,
+      '--prompt', prompt,
+    ];
+
+    if (this.config.model) {
+      args.push('--model', this.config.model);
+    }
+
+    logger.info(`[Kimi ${sessionId}] Executing: ${kimiCliPath} ${args.join(' ')}`);
+
+    const kimiProcess = spawn(kimiCliPath, args, {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: workDir,
+    });
+
+    let buffer = '';
+    const sentTextHashes = new Set<string>();
+    const sentToolIds = new Set<string>();
+    const messageQueue: AgentMessage[] = [];
+
+    kimiProcess.stdout?.on('data', (data: Buffer) => {
+      buffer += data.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || ''; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const message = JSON.parse(line.trim());
+            // Process message and add to queue
+            for (const agentMessage of this.processKimiMessage(message, sessionId, sentTextHashes, sentToolIds)) {
+              messageQueue.push(agentMessage);
+            }
+          } catch (parseError) {
+            logger.warn(`[Kimi ${sessionId}] Failed to parse JSON: ${line}`);
+          }
+        }
+      }
+    });
+
+    kimiProcess.stderr?.on('data', (data: Buffer) => {
+      logger.error(`[Kimi ${sessionId}] STDERR: ${data.toString()}`);
+    });
+
+    // Track process completion
+    let processCompleted = false;
+    const processPromise = new Promise<void>((resolve, reject) => {
+      kimiProcess.on('close', (code: number) => {
+        processCompleted = true;
+        if (code === 0) {
+          logger.info(`[Kimi ${sessionId}] Process completed successfully`);
+          resolve();
+        } else {
+          logger.error(`[Kimi ${sessionId}] Process exited with code: ${code}`);
+          reject(new Error(`Kimi CLI process exited with code ${code}`));
+        }
+      });
+
+      kimiProcess.on('error', (processError: Error) => {
+        processCompleted = true;
+        logger.error(`[Kimi ${sessionId}] Process error: ${processError}`);
+        reject(processError);
+      });
+    });
+
+    // Yield messages as they arrive
+    while (!processCompleted) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      while (messageQueue.length > 0) {
+        const message = messageQueue.shift();
+        if (message) {
+          yield message;
+        }
+      }
+    }
+
+    // Wait for process to complete and handle errors
+    await processPromise;
+
+    // Yield any remaining messages
+    while (messageQueue.length > 0) {
+      const message = messageQueue.shift();
+      if (message) {
+        yield message;
+      }
+    }
+  }
+
+  /**
+   * Process Kimi CLI messages and convert to AgentMessage format
+   */
+  private *processKimiMessage(
+    message: any,
+    sessionId: string,
+    sentTextHashes: Set<string>,
+    sentToolIds: Set<string>
+  ): Generator<AgentMessage> {
+    if (message.role === 'assistant') {
+      if (message.content) {
+        for (const block of message.content) {
+          if (block.type === 'text') {
+            const textHash = block.text.slice(0, 100);
+            if (!sentTextHashes.has(textHash)) {
+              sentTextHashes.add(textHash);
+              logger.info(`[Kimi ${sessionId}] Text: ${block.text.slice(0, 50)}...`);
+              yield { type: 'text', content: block.text };
+            }
+          }
+        }
+      }
+
+      if (message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.type === 'function') {
+            const toolId = toolCall.id;
+            if (!sentToolIds.has(toolId)) {
+              sentToolIds.add(toolId);
+              logger.info(`[Kimi ${sessionId}] Tool: ${toolCall.function.name}`);
+              yield {
+                type: 'tool_use',
+                id: toolId,
+                name: toolCall.function.name,
+                input: JSON.parse(toolCall.function.arguments || '{}'),
+              };
+            }
+          }
+        }
+      }
+    }
+
+    if (message.role === 'tool') {
+      logger.info(`[Kimi ${sessionId}] Tool result for: ${message.tool_call_id}`);
+      yield {
+        type: 'tool_result',
+        toolUseId: message.tool_call_id,
+        output: Array.isArray(message.content)
+          ? message.content.map((c: any) => c.text || '').join('\n')
+          : message.content,
+        isError: false,
+      };
+    }
+  }
+
+  /**
+   * Direct execution mode (without planning)
+   */
+  async *run(
+    prompt: string,
+    options?: AgentOptions
+  ): AsyncGenerator<AgentMessage> {
+    const session = this.createSession('executing');
+    yield { type: 'session', sessionId: session.id };
+
+    const sessionCwd = getSessionWorkDir(
+      options?.cwd || this.config.workDir,
+      prompt,
+      options?.taskId
+    );
+
+    await ensureDir(sessionCwd);
+    logger.info(`[Kimi ${session.id}] Working directory: ${sessionCwd}`);
+    logger.info(`[Kimi ${session.id}] Direct execution started`);
+
+    if (options?.conversation && options.conversation.length > 0) {
+      logger.info(`[Kimi ${session.id}] Conversation history: ${options.conversation.length} messages`);
+    }
+
+    // Handle image attachments
+    let imageInstruction = '';
+    if (options?.images && options.images.length > 0) {
+      logger.info(`[Kimi ${session.id}] Processing ${options.images.length} image(s)`);
+      const imagePaths = await saveImagesToDisk(options.images, sessionCwd);
+      logger.info(`[Kimi ${session.id}] Saved ${imagePaths.length} images to disk: ${imagePaths.join(', ')}`);
+
+      if (imagePaths.length > 0) {
+        imageInstruction = `
+## 🖼️ MANDATORY IMAGE ANALYSIS - DO THIS FIRST
+
+**STOP! Before doing anything else, you MUST read the attached image(s).**
+
+The user has attached ${imagePaths.length} image file(s):
+${imagePaths.map((p, i) => `${i + 1}. ${p}`).join('\n')}
+
+**YOUR FIRST ACTION MUST BE:**
+Use the ReadFile tool to view each image file listed above.
+
+**CRITICAL RULES:**
+- DO NOT respond to the user's question until you have READ and SEEN the actual image content
+- DO NOT guess or assume what the image contains
+- After reading the image, describe what you actually see in the image
+- Base your response ONLY on the actual visual content you observe
+
+---
+User's request (answer this AFTER reading the images):
+`;
+      }
+    }
+
+    // Format conversation history
+    const conversationContext = this.formatConversationHistory(options?.conversation);
+
+    // Build sandbox options
+    const sandboxOpts: SandboxOptions | undefined = options?.sandbox?.enabled
+      ? {
+          enabled: true,
+          image: options.sandbox.image,
+          apiEndpoint: options.sandbox.apiEndpoint || SANDBOX_API_URL,
+        }
+      : undefined;
+
+    // Combine prompt with context and instructions
+    const enhancedPrompt = imageInstruction
+      ? imageInstruction + prompt + '\n\n' + getWorkspaceInstruction(sessionCwd, sandboxOpts) + conversationContext
+      : getWorkspaceInstruction(sessionCwd, sandboxOpts) + conversationContext + prompt;
+
+    try {
+      yield* this.executeKimiCommand(enhancedPrompt, sessionCwd, session.id);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`[Kimi ${session.id}] Error occurred`, { error: errorMessage });
+
+      const isApiKeyError = errorMessage.includes('API key') ||
+        errorMessage.includes('authentication') ||
+        errorMessage.includes('401') ||
+        errorMessage.includes('403');
+
+      if (isApiKeyError) {
+        yield { type: 'error', message: '__API_KEY_ERROR__' };
+      } else {
+        yield { type: 'error', message: `__INTERNAL_ERROR__|${LOG_FILE_PATH}` };
+      }
+    } finally {
+      this.sessions.delete(session.id);
+      yield { type: 'done' };
+    }
+  }
+
+  /**
+   * Planning phase only
+   */
+  async *plan(
+    prompt: string,
+    options?: PlanOptions
+  ): AsyncGenerator<AgentMessage> {
+    const session = this.createSession('planning');
+    yield { type: 'session', sessionId: session.id };
+
+    const sessionCwd = getSessionWorkDir(
+      options?.cwd || this.config.workDir,
+      prompt,
+      options?.taskId
+    );
+
+    await ensureDir(sessionCwd);
+    logger.info(`[Kimi ${session.id}] Working directory: ${sessionCwd}`);
+    logger.info(`[Kimi ${session.id}] Planning phase started`);
+
+    const workspaceInstruction = `
+## CRITICAL: Output Directory
+**ALL files must be saved to: ${sessionCwd}**
+If you need to create any files during planning, use this directory.
+`;
+    const planningPrompt = workspaceInstruction + PLANNING_INSTRUCTION + prompt;
+
+    let fullResponse = '';
+
+    try {
+      const kimiCliPath = await ensureKimiCli();
+      if (!kimiCliPath) {
+        yield { type: 'error', message: '__KIMI_CLI_NOT_FOUND__' };
+        yield { type: 'done' };
+        return;
+      }
+
+      yield* this.executeKimiCommand(planningPrompt, sessionCwd, session.id);
+
+      // For now, we'll just return the response as a direct answer
+      // TODO: Parse planning response when we understand Kimi's output format better
+      yield { type: 'direct_answer', content: fullResponse || 'Planning completed. Ready to execute.' };
+    } catch (error) {
+      logger.error(`[Kimi ${session.id}] Planning error:`, error);
+      yield {
+        type: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      yield { type: 'done' };
+    }
+  }
+
+  /**
+   * Execute an approved plan
+   */
+  async *execute(options: ExecuteOptions): AsyncGenerator<AgentMessage> {
+    const session = this.createSession('executing');
+    yield { type: 'session', sessionId: session.id };
+
+    const plan = options.plan || this.getPlan(options.planId);
+    if (!plan) {
+      logger.error(`[Kimi ${session.id}] Plan not found: ${options.planId}`);
+      yield { type: 'error', message: `Plan not found: ${options.planId}` };
+      yield { type: 'done' };
+      return;
+    }
+
+    logger.info(`[Kimi ${session.id}] Using plan: ${plan.id} (${plan.goal})`);
+
+    const sessionCwd = getSessionWorkDir(
+      options.cwd || this.config.workDir,
+      options.originalPrompt,
+      options.taskId
+    );
+
+    await ensureDir(sessionCwd);
+    logger.info(`[Kimi ${session.id}] Working directory: ${sessionCwd}`);
+
+    const sandboxOpts: SandboxOptions | undefined = options.sandbox?.enabled
+      ? {
+          enabled: true,
+          image: options.sandbox.image,
+          apiEndpoint: options.sandbox.apiEndpoint || SANDBOX_API_URL,
+        }
+      : undefined;
+
+    const executionPrompt =
+      formatPlanForExecution(plan, sessionCwd, sandboxOpts) +
+      '\n\nOriginal request: ' + options.originalPrompt;
+
+    logger.info(`[Kimi ${session.id}] Execution phase started for plan: ${options.planId}`);
+
+    try {
+      yield* this.executeKimiCommand(executionPrompt, sessionCwd, session.id);
+    } catch (error) {
+      logger.error(`[Kimi ${session.id}] Execution error:`, error);
+      yield {
+        type: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      logger.info(`[Kimi ${session.id}] Execution done`);
+      this.deletePlan(options.planId);
+      this.sessions.delete(session.id);
+      yield { type: 'done' };
+    }
+  }
+}
+
+/**
+ * Factory function to create Kimi agent
+ */
+export function createKimiAgent(config: AgentConfig): KimiAgent {
+  return new KimiAgent(config);
+}
+
+/**
+ * Kimi agent plugin definition
+ */
+export const kimiPlugin: AgentPlugin = defineAgentPlugin({
+  metadata: KIMI_METADATA,
+  factory: (config) => createKimiAgent(config),
+});

--- a/src-api/src/extensions/agent/kimi/utils.ts
+++ b/src-api/src/extensions/agent/kimi/utils.ts
@@ -1,0 +1,251 @@
+/**
+ * Kimi CLI Utilities
+ *
+ * Path detection and utility functions for Kimi CLI integration
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readdirSync } from 'fs';
+import { arch, homedir, platform } from 'os';
+import { join } from 'path';
+
+/**
+ * Build extended PATH that includes common package manager bin locations
+ */
+function getExtendedPath(): string {
+  const home = homedir();
+  const os = platform();
+  const isWindows = os === 'win32';
+  const pathSeparator = isWindows ? ';' : ':';
+
+  const paths = [process.env.PATH || ''];
+
+  if (isWindows) {
+    // Windows paths
+    paths.push(
+      join(home, 'AppData', 'Roaming', 'npm'),
+      join(home, 'AppData', 'Local', 'Programs', 'nodejs'),
+      join(home, '.volta', 'bin'),
+      'C:\\Program Files\\nodejs',
+      'C:\\Program Files (x86)\\nodejs'
+    );
+  } else {
+    // Unix paths
+    paths.push(
+      '/usr/local/bin',
+      '/opt/homebrew/bin',
+      `${home}/.local/bin`,
+      `${home}/.npm-global/bin`,
+      `${home}/.volta/bin`,
+      `${home}/code/node/npm_global/bin`
+    );
+
+    // Add Python package paths for Kimi CLI
+    paths.push(
+      `${home}/.local/bin`,
+      `${home}/Library/Python/3.11/bin`,
+      `${home}/Library/Python/3.12/bin`,
+      `${home}/Library/Python/3.13/bin`,
+      '/usr/local/bin',
+      '/opt/homebrew/bin'
+    );
+  }
+
+  return paths.join(pathSeparator);
+}
+
+/**
+ * Get the path to the kimi CLI executable.
+ * Priority order:
+ * 1. User-installed Kimi CLI (via which/where with extended PATH)
+ * 2. Common Python package locations
+ * 3. Environment variable KIMI_CLI_PATH
+ */
+export function getKimiCliPath(): string | undefined {
+  const os = platform();
+  const extendedEnv = { ...process.env, PATH: getExtendedPath() };
+
+  // Priority 1: Check for user-installed Kimi CLI via 'which'/'where' with extended PATH
+  try {
+    if (os === 'win32') {
+      const whereResult = execSync('where kimi', {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        env: extendedEnv,
+      }).trim();
+      const firstPath = whereResult.split('\n')[0];
+      if (firstPath && existsSync(firstPath)) {
+        console.log(
+          `[Kimi] Found user-installed Kimi CLI at: ${firstPath}`
+        );
+        return firstPath;
+      }
+    } else {
+      // Try with login shell to get user's PATH
+      try {
+        const shellWhichResult = execSync('bash -l -c "which kimi"', {
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          env: extendedEnv,
+        }).trim();
+        if (shellWhichResult && existsSync(shellWhichResult)) {
+          console.log(
+            `[Kimi] Found user-installed Kimi CLI at: ${shellWhichResult}`
+          );
+          return shellWhichResult;
+        }
+      } catch {
+        // Try zsh if bash fails
+        try {
+          const zshWhichResult = execSync('zsh -l -c "which kimi"', {
+            encoding: 'utf-8',
+            stdio: 'pipe',
+            env: extendedEnv,
+          }).trim();
+          if (zshWhichResult && existsSync(zshWhichResult)) {
+            console.log(
+              `[Kimi] Found user-installed Kimi CLI at: ${zshWhichResult}`
+            );
+            return zshWhichResult;
+          }
+        } catch {
+          // Fall through to other checks
+        }
+      }
+
+      // Fallback: simple which with extended PATH
+      const whichResult = execSync('which kimi', {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        env: extendedEnv,
+      }).trim();
+      if (whichResult && existsSync(whichResult)) {
+        console.log(
+          `[Kimi] Found user-installed Kimi CLI at: ${whichResult}`
+        );
+        return whichResult;
+      }
+    }
+  } catch {
+    // 'which kimi' failed, user doesn't have kimi installed globally
+  }
+
+  // Priority 2: Check common install locations
+  const home = homedir();
+  const commonPaths =
+    os === 'win32'
+      ? [
+          join(home, 'AppData', 'Local', 'Programs', 'kimi', 'kimi.exe'),
+          join(home, 'AppData', 'Roaming', 'Python', 'Scripts', 'kimi.exe'),
+        ]
+      : [
+          '/usr/local/bin/kimi',
+          '/opt/homebrew/bin/kimi',
+          join(home, '.local', 'bin', 'kimi'),
+          // Python user-site directories
+          join(home, 'Library', 'Python', '3.11', 'bin', 'kimi'),
+          join(home, 'Library', 'Python', '3.12', 'bin', 'kimi'),
+          join(home, 'Library', 'Python', '3.13', 'bin', 'kimi'),
+          // pyenv paths
+          join(home, '.pyenv', 'shims', 'kimi'),
+        ];
+
+  for (const path of commonPaths) {
+    if (existsSync(path)) {
+      console.log(`[Kimi] Found Kimi CLI at: ${path}`);
+      return path;
+    }
+  }
+
+  // Priority 3: Check if KIMI_CLI_PATH env var is set
+  if (
+    process.env.KIMI_CLI_PATH &&
+    existsSync(process.env.KIMI_CLI_PATH)
+  ) {
+    console.log(
+      `[Kimi] Using KIMI_CLI_PATH: ${process.env.KIMI_CLI_PATH}`
+    );
+    return process.env.KIMI_CLI_PATH;
+  }
+
+  console.warn(
+    '[Kimi] Kimi CLI not found. Please install it: pip install kimi-cli'
+  );
+  return undefined;
+}
+
+/**
+ * Install Kimi CLI automatically
+ * Returns true if installation was successful
+ */
+export async function installKimiCli(): Promise<boolean> {
+  console.log('[Kimi] Attempting to install Kimi CLI...');
+
+  try {
+    // Try pip install
+    console.log('[Kimi] Installing via pip...');
+    execSync('curl -L code.kimi.com/install.sh | bash', {
+      encoding: 'utf-8',
+      stdio: 'inherit',
+    });
+    return true;
+  } catch (error) {
+    console.log('[Kimi] bash failed, trying pip3...');
+    console.error('[Kimi] Failed to install Kimi CLI:', error);
+    return false;
+  }
+}
+
+/**
+ * Ensure Kimi CLI is available, install if necessary
+ */
+export async function ensureKimiCli(): Promise<string | undefined> {
+  let path = getKimiCliPath();
+
+  if (!path) {
+    console.log(
+      '[Kimi] Kimi CLI not found, attempting automatic installation...'
+    );
+
+    const installed = await installKimiCli();
+    if (installed) {
+      // Re-check after installation
+      path = getKimiCliPath();
+    }
+  }
+
+  return path;
+}
+
+/**
+ * Check if running in a packaged app environment
+ */
+export function isPackagedApp(): boolean {
+  // Check if running from a bundled binary (via pkg)
+  // @ts-expect-error - pkg specific property
+  if (process.pkg) {
+    return true;
+  }
+
+  // Check for Tauri environment
+  if (process.env.TAURI_ENV || process.env.TAURI) {
+    return true;
+  }
+
+  // Check if executable path contains typical app bundle paths
+  const execPath = process.execPath;
+  if (
+    execPath.includes('.app/Contents/MacOS') ||
+    execPath.includes('\\WorkAny\\') ||
+    execPath.includes('/WorkAny/')
+  ) {
+    return true;
+  }
+
+  // Check for production environment
+  if (process.env.NODE_ENV === 'production') {
+    return true;
+  }
+
+  return false;
+}

--- a/src-api/src/shared/types/agent.ts
+++ b/src-api/src/shared/types/agent.ts
@@ -90,7 +90,7 @@ export interface AgentRequest {
   // MCP configuration
   mcpConfig?: McpConfigRequest;
   // Provider selection (optional, defaults to env config)
-  provider?: 'claude' | 'deepagents';
+  provider?: 'claude' | 'deepagents'|'kimi';
   // Custom model configuration
   modelConfig?: ModelConfig;
   // Sandbox configuration for isolated execution

--- a/src/components/home/AgentMessages.tsx
+++ b/src/components/home/AgentMessages.tsx
@@ -187,6 +187,34 @@ function ErrorMessage({ message }: { message: string }) {
     );
   }
 
+  // Check for Kimi CLI not found error
+  if (message === '__KIMI_CLI_NOT_FOUND__') {
+    return (
+      <>
+        <div className="flex flex-col gap-3 rounded-lg bg-amber-50 p-4 dark:bg-amber-950">
+          <div className="flex items-start gap-2 text-sm text-amber-700 dark:text-amber-300">
+            <AlertCircle className="mt-0.5 size-4 shrink-0" />
+            <span>{t.common.errors.kimiCliNotFound}</span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            onClick={() => setSettingsOpen(true)}
+          >
+            <Settings className="mr-2 size-4" />
+            {t.common.errors.configureModel}
+          </Button>
+        </div>
+        <SettingsModal
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          initialCategory="model"
+        />
+      </>
+    );
+  }
+
   // Check for API key error
   if (message === '__API_KEY_ERROR__') {
     return (

--- a/src/config/locale/messages/en/common.ts
+++ b/src/config/locale/messages/en/common.ts
@@ -52,6 +52,8 @@ export default {
       'AI model not configured. Please configure a custom model (API URL, API key, model name) before starting a conversation.',
     claudeCodeNotFound:
       'Claude Code is not installed or unavailable. Please configure a custom AI model in Settings, or install Claude Code (npm install -g @anthropic-ai/claude-code)',
+    kimiCliNotFound:
+      'Kimi CLI is not installed or unavailable. Please configure a custom AI model in Settings, or install Kimi CLI (curl -L code.kimi.com/install.sh | bash)',
     configureModel: 'Configure Model',
     apiKeyError:
       'AI model request failed. Please check your model configuration (API URL, API key, model name, etc.)',

--- a/src/config/locale/messages/en/settings.ts
+++ b/src/config/locale/messages/en/settings.ts
@@ -34,8 +34,12 @@ export default {
   agentRuntimeDescription: 'The AI agent that executes tasks',
   runtimeClaudeCode: 'Claude Code',
   runtimeClaudeCodeDescription: 'Powered by Claude Code to orchestrate tasks',
+  runtimeKimiCode: 'Kimi Code',
+  runtimeKimiCodeDescription: 'Powered by Kimi CLI to orchestrate tasks',
   installClaudeCode: 'Claude Code not installed',
   installClaudeCodeHint: 'Run: npm install -g @anthropic-ai/claude-code',
+  installKimiCode: 'Kimi CLI not installed',
+  installKimiCodeHint: 'Run: curl -L code.kimi.com/install.sh | bash',
 
   // Code Environment
   codeEnvironment: 'Code Environment',

--- a/src/config/locale/messages/zh/common.ts
+++ b/src/config/locale/messages/zh/common.ts
@@ -50,6 +50,8 @@ export default {
       '尚未配置 AI 模型。请先配置自定义模型（API 地址、密钥、模型名称）后再开始对话。',
     claudeCodeNotFound:
       'Claude Code 未安装或不可用。请在设置中配置自定义 AI 模型，或安装 Claude Code（npm install -g @anthropic-ai/claude-code）',
+    kimiCliNotFound:
+      'Kimi CLI 未安装或不可用。请在设置中配置自定义 AI 模型，或安装 Kimi CLI（curl -L code.kimi.com/install.sh | bash）',
     configureModel: '配置模型',
     apiKeyError: 'AI 模型接口请求失败，请检查模型配置是否正确（API 地址、密钥、模型名称等）',
     configureApiKey: '前往配置',

--- a/src/config/locale/messages/zh/settings.ts
+++ b/src/config/locale/messages/zh/settings.ts
@@ -34,8 +34,12 @@ export default {
   agentRuntimeDescription: '执行任务的 AI 智能体',
   runtimeClaudeCode: 'Claude Code',
   runtimeClaudeCodeDescription: '由 Claude Code 驱动任务流程',
+  runtimeKimiCode: 'Kimi Code',
+  runtimeKimiCodeDescription: '由 Kimi CLI 驱动任务流程',
   installClaudeCode: 'Claude Code 未安装',
   installClaudeCodeHint: '运行: npm install -g @anthropic-ai/claude-code',
+  installKimiCode: 'Kimi CLI 未安装',
+  installKimiCodeHint: '运行: curl -L code.kimi.com/install.sh | bash',
 
   // Code Environment
   codeEnvironment: '代码运行环境',

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -77,7 +77,7 @@ export const defaultSandboxProviders: SandboxProviderSetting[] = [
 // Agent Runtime Settings
 // ============================================================================
 
-export type AgentRuntimeType = 'claude' | 'codex' | 'deepagents' | 'custom';
+export type AgentRuntimeType = 'claude' | 'codex' | 'deepagents' | 'kimi' | 'custom';
 
 export interface AgentRuntimeSetting {
   id: string;
@@ -110,6 +110,15 @@ export const defaultAgentRuntimes: AgentRuntimeSetting[] = [
     enabled: false,
     config: {
       model: 'codex',
+    },
+  },
+  {
+    id: 'kimi',
+    type: 'kimi',
+    name: 'Kimi Code (Moonshot)',
+    enabled: true,
+    config: {
+      model: 'kimi-for-coding',
     },
   },
 ];
@@ -318,6 +327,17 @@ export const defaultProviders: AIProvider[] = [
     models: ['MiniMaxAI/MiniMax-M2.1', 'zai-org/GLM-4.7'],
     icon: 'S',
     apiKeyUrl: 'https://cloud.siliconflow.com/me/account/ak',
+    canDelete: true,
+  },
+  {
+    id: 'kimi',
+    name: 'Kimi (Moonshot)',
+    apiKey: '',
+    baseUrl: 'https://api.kimi.com/coding/v1',
+    enabled: true,
+    models: ['kimi-for-coding'],
+    icon: 'K',
+    apiKeyUrl: 'https://www.kimi.com/code/docs/en/',
     canDelete: true,
   },
 ];


### PR DESCRIPTION
- Add KimiAgent implementation with full streaming and tool support
- Support automatic kimi-cli detection and installation
- Add frontend configuration and Chinese/English localization
- Enable dynamic provider switching between Claude/Codex/Kimi
- Complete plugin system integration as 4th official agent
- Maintain full backward compatibility with existing features
<img width="1012" height="711" alt="Screenshot 2026-02-01 at 12 02 50 AM" src="https://github.com/user-attachments/assets/90ce6e30-732c-4cb1-911f-890e6b43f69a" />
<img width="894" height="768" alt="Screenshot 2026-02-01 at 12 03 21 AM" src="https://github.com/user-attachments/assets/63c59270-ab8c-4aed-8418-72d85cc788da" />
