### PR TITLE
fix: soften message scrollbars

### DIFF
--- a/src/app/pages/TaskDetail.tsx
+++ b/src/app/pages/TaskDetail.tsx
@@ -933,7 +933,7 @@ function TaskDetailContent() {
             <div
               ref={messagesContainerRef}
               className={cn(
-                'relative flex-1 overflow-x-hidden overflow-y-auto',
+                'scrollbar-soft relative flex-1 overflow-x-hidden overflow-y-auto',
                 !isPreviewVisible &&
                   !isRightSidebarVisible &&
                   'flex justify-center'

--- a/src/components/task/RightSidebar.tsx
+++ b/src/components/task/RightSidebar.tsx
@@ -1224,7 +1224,7 @@ export function RightSidebar({
   };
 
   return (
-    <div className="bg-background flex h-full flex-col overflow-x-hidden overflow-y-auto">
+    <div className="scrollbar-blend bg-background flex h-full flex-col overflow-x-hidden overflow-y-auto">
       {/* 1. Workspace Section */}
       <CollapsibleSection
         title={t.task.workspace || 'Workspace'}

--- a/src/config/style/global.css
+++ b/src/config/style/global.css
@@ -30,6 +30,37 @@
   scrollbar-width: none; /* Firefox */
 }
 
+/* Blend scrollbars into background (transparent track) */
+.scrollbar-blend {
+  scrollbar-color: var(--muted-foreground) transparent; /* Firefox */
+}
+.scrollbar-blend::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Soft, light scrollbars (transparent track + subtle thumb) */
+.scrollbar-soft {
+  scrollbar-color: rgba(0, 0, 0, 0.25) transparent; /* Firefox */
+}
+.dark .scrollbar-soft {
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent; /* Firefox */
+}
+.scrollbar-soft::-webkit-scrollbar {
+  width: 8px;
+}
+.scrollbar-soft::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-soft::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.dark .scrollbar-soft::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
 input,
 select,
 textarea {


### PR DESCRIPTION
## Summary
- Soften message area scrollbar (light thumb + transparent track)
- Blend right sidebar scrollbar track with background

## Screenshots
- Before/After: will be attached by the reporter

## Testing
- Not run (Tauri dev requires sidecar resources locally)

## Issues
- Fixes #20

## Origin：
<img width="2400" height="1600" alt="df4446b4826e0253f997327cfb508bdb" src="https://github.com/user-attachments/assets/5dc3d6b9-e40d-4768-ba08-b6088a534283" />
## Modify：
<img width="2400" height="1600" alt="2e4897d0bd0862b2a1ed6a199e90cc03" src="https://github.com/user-attachments/assets/ac298fad-033c-4032-9840-d4139d93896e" />
