### PR TITLE
fix: align agent session ids across service and providers

### DIFF
--- a/src-api/src/core/agent/base.ts
+++ b/src-api/src/core/agent/base.ts
@@ -60,13 +60,16 @@ export abstract class BaseAgent implements IAgent {
   /**
    * Create a new session
    */
-  protected createSession(phase: AgentSession['phase'] = 'idle'): AgentSession {
+  protected createSession(
+    phase: AgentSession['phase'] = 'idle',
+    overrides?: { id?: string; abortController?: AbortController }
+  ): AgentSession {
     const session: AgentSession = {
-      id: nanoid(),
+      id: overrides?.id || nanoid(),
       createdAt: new Date(),
       phase,
       isAborted: false,
-      abortController: new AbortController(),
+      abortController: overrides?.abortController || new AbortController(),
       config: this.config,
     };
     this.sessions.set(session.id, session);

--- a/src-api/src/extensions/agent/claude/index.ts
+++ b/src-api/src/extensions/agent/claude/index.ts
@@ -1192,7 +1192,10 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     prompt: string,
     options?: AgentOptions
   ): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('executing');
+    const session = this.createSession('executing', {
+      id: options?.sessionId,
+      abortController: options?.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     const sessionCwd = getSessionWorkDir(
@@ -1496,7 +1499,10 @@ User's request (answer this AFTER reading the images):
     prompt: string,
     options?: PlanOptions
   ): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('planning');
+    const session = this.createSession('planning', {
+      id: options?.sessionId,
+      abortController: options?.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     // Get session working directory
@@ -1615,7 +1621,10 @@ If you need to create any files during planning, use this directory.
    * Execute an approved plan
    */
   async *execute(options: ExecuteOptions): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('executing');
+    const session = this.createSession('executing', {
+      id: options.sessionId,
+      abortController: options.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     // Use the plan passed in options, or fall back to local lookup

--- a/src-api/src/extensions/agent/codex/index.ts
+++ b/src-api/src/extensions/agent/codex/index.ts
@@ -299,7 +299,10 @@ export class CodexAgent extends BaseAgent {
     prompt: string,
     options?: AgentOptions
   ): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('executing');
+    const session = this.createSession('executing', {
+      id: options?.sessionId,
+      abortController: options?.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     const sessionCwd = await getSessionWorkDir(
@@ -382,7 +385,10 @@ export class CodexAgent extends BaseAgent {
     prompt: string,
     options?: PlanOptions
   ): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('planning');
+    const session = this.createSession('planning', {
+      id: options?.sessionId,
+      abortController: options?.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     const sessionCwd = await getSessionWorkDir(
@@ -483,7 +489,10 @@ Please respond ONLY with JSON in this exact format, no other text:
    * Execute an approved plan
    */
   async *execute(options: ExecuteOptions): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('executing');
+    const session = this.createSession('executing', {
+      id: options.sessionId,
+      abortController: options.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     // Use the plan passed in options, or fall back to local lookup

--- a/src-api/src/extensions/agent/deepagents/index.ts
+++ b/src-api/src/extensions/agent/deepagents/index.ts
@@ -117,7 +117,10 @@ export class DeepAgentsAdapter extends BaseAgent {
     prompt: string,
     options?: AgentOptions
   ): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('executing');
+    const session = this.createSession('executing', {
+      id: options?.sessionId,
+      abortController: options?.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     console.log(`[DeepAgents ${session.id}] Direct execution started`);
@@ -191,7 +194,10 @@ export class DeepAgentsAdapter extends BaseAgent {
     prompt: string,
     _options?: PlanOptions
   ): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('planning');
+    const session = this.createSession('planning', {
+      id: _options?.sessionId,
+      abortController: _options?.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     console.log(`[DeepAgents ${session.id}] Planning phase started`);
@@ -259,7 +265,10 @@ export class DeepAgentsAdapter extends BaseAgent {
    * Execute an approved plan
    */
   async *execute(options: ExecuteOptions): AsyncGenerator<AgentMessage> {
-    const session = this.createSession('executing');
+    const session = this.createSession('executing', {
+      id: options.sessionId,
+      abortController: options.abortController,
+    });
     yield { type: 'session', sessionId: session.id };
 
     // Use the plan passed in options, or fall back to local lookup

--- a/src-api/src/shared/services/agent.ts
+++ b/src-api/src/shared/services/agent.ts
@@ -19,6 +19,7 @@ import {
   type SkillsConfig,
   type TaskPlan,
 } from '@/core/agent';
+import { nanoid } from 'nanoid';
 // ============================================================================
 // Logging - uses shared logger (writes to ~/.workany/logs/workany.log)
 // ============================================================================
@@ -75,7 +76,7 @@ export function createSession(
   phase: 'plan' | 'execute' = 'plan'
 ): AgentSession {
   const session: AgentSession = {
-    id: Date.now().toString(),
+    id: nanoid(),
     createdAt: new Date(),
     phase: phase === 'plan' ? 'planning' : 'executing',
     isAborted: false,


### PR DESCRIPTION
## Summary
- Reuse service-generated sessionId + abortController inside agent providers (Claude/Codex/DeepAgents)
- Generate service sessionId with nanoid for uniqueness

## Context
Fixes sessionId mismatch between API layer and agent providers, which caused /agent/stop to miss active sessions.

Fixes #24

## Test
- pnpm --filter workany-api build
- Manual local test: start API with PORT=3035 AGENT_PROVIDER=deepagents, then run a local SSE plan/execute flow and call /agent/stop on the returned sessionId (observed 200 + stop handled in logs)
