### PR TITLE
fix: sync tauri window theme

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-set-theme",
     "opener:default",
     "sql:default",
     "sql:allow-load",

--- a/src/shared/providers/theme-provider.tsx
+++ b/src/shared/providers/theme-provider.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
 import {
   accentColors,
   getSettings,
@@ -12,6 +13,17 @@ import {
   type AccentColor,
   type BackgroundStyle,
 } from '@/shared/db/settings';
+
+async function syncTauriTheme(theme: 'light' | 'dark' | 'system') {
+  if (!isTauri()) return;
+  try {
+    const { getCurrentWindow } = await import('@tauri-apps/api/window');
+    // Pass null to follow system theme
+    await getCurrentWindow().setTheme(theme === 'system' ? null : theme);
+  } catch (e) {
+    console.warn('[Theme] Failed to sync Tauri window theme:', e);
+  }
+}
 
 type Theme = 'light' | 'dark' | 'system';
 type ResolvedTheme = 'light' | 'dark';
@@ -111,6 +123,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     applyAccentColor(accentColor, resolved);
     applyBackgroundStyle(backgroundStyle);
   }, [theme, accentColor, backgroundStyle]);
+
+  useEffect(() => {
+    void syncTauriTheme(theme);
+  }, [theme]);
 
   // Listen for system theme changes
   useEffect(() => {


### PR DESCRIPTION
# Summary
- Sync native Tauri window theme to app theme setting (light/dark/system)
- Add window theme permission for macOS menu/title bar updates

# Testing
- Not run (UI change)

# Origin:
<img width="2400" height="1600" alt="63d9cf95b0009a39a9912326e3c784cb" src="https://github.com/user-attachments/assets/60565604-c7a0-48e9-9ec7-995d89cc5f66" />


# Modify
<img width="2400" height="1600" alt="615e831c547986e58aa1e8e9887fc377" src="https://github.com/user-attachments/assets/53089efd-32b9-43cd-9c22-20460bb2bd37" />
