### PR TITLE
fix: enforce response language by settings

### DIFF
--- a/src-api/src/app/api/agent.ts
+++ b/src-api/src/app/api/agent.ts
@@ -67,7 +67,7 @@ agent.post('/plan', async (c) => {
 
   const session = createSession('plan');
   const readable = createSSEStream(
-    runPlanningPhase(body.prompt, session, body.modelConfig)
+    runPlanningPhase(body.prompt, session, body.modelConfig, body.language)
   );
 
   return new Response(readable, { headers: SSE_HEADERS });
@@ -94,6 +94,7 @@ agent.post('/execute', async (c) => {
       appDirEnabled: boolean;
       mcpConfigPath?: string;
     };
+    language?: string;
   }>();
 
   console.log('[AgentAPI] POST /execute received:', {
@@ -129,7 +130,8 @@ agent.post('/execute', async (c) => {
       body.modelConfig,
       body.sandboxConfig,
       body.skillsConfig,
-      body.mcpConfig
+      body.mcpConfig,
+      body.language
     )
   );
 
@@ -189,7 +191,8 @@ agent.post('/', async (c) => {
       body.sandboxConfig,
       body.images,
       body.skillsConfig,
-      body.mcpConfig
+      body.mcpConfig,
+      body.language
     )
   );
 

--- a/src-api/src/core/agent/types.ts
+++ b/src-api/src/core/agent/types.ts
@@ -139,6 +139,8 @@ export interface AgentOptions {
   sessionId?: string;
   /** Conversation history */
   conversation?: ConversationMessage[];
+  /** Preferred response language (e.g., en-US, zh-CN) */
+  language?: string;
   /** Working directory */
   cwd?: string;
   /** Allowed tools */

--- a/src-api/src/extensions/agent/codex/index.ts
+++ b/src-api/src/extensions/agent/codex/index.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 
 import {
   BaseAgent,
+  buildLanguageInstruction,
   formatPlanForExecution,
   getWorkspaceInstruction,
   parsePlanFromResponse,
@@ -319,9 +320,15 @@ export class CodexAgent extends BaseAgent {
         }
       : undefined;
 
+    const languageInstruction = buildLanguageInstruction(
+      options?.language,
+      prompt
+    );
     // Add workspace instruction to prompt
     const enhancedPrompt =
-      getWorkspaceInstruction(sessionCwd, sandboxOpts) + prompt;
+      getWorkspaceInstruction(sessionCwd, sandboxOpts) +
+      languageInstruction +
+      prompt;
 
     // Ensure Codex CLI is installed
     const codexPath = await ensureCodex();
@@ -395,7 +402,11 @@ export class CodexAgent extends BaseAgent {
 
     // For Codex, we'll use a simplified planning approach
     // Since Codex doesn't have a native planning mode, we'll ask it to generate a plan
-    const planningPrompt = `${PLANNING_INSTRUCTION}${prompt}
+    const languageInstruction = buildLanguageInstruction(
+      options?.language,
+      prompt
+    );
+    const planningPrompt = `${PLANNING_INSTRUCTION}${languageInstruction}${prompt}
 
 Please respond ONLY with JSON in this exact format, no other text:
 {
@@ -514,7 +525,13 @@ Please respond ONLY with JSON in this exact format, no other text:
       : undefined;
 
     const executionPrompt =
-      formatPlanForExecution(plan, sessionCwd, sandboxOpts) +
+      formatPlanForExecution(
+        plan,
+        sessionCwd,
+        sandboxOpts,
+        options.language,
+        options.originalPrompt
+      ) +
       '\n\nOriginal request: ' +
       options.originalPrompt;
 

--- a/src-api/src/shared/services/agent.ts
+++ b/src-api/src/shared/services/agent.ts
@@ -148,13 +148,15 @@ export function deletePlan(planId: string): boolean {
 export async function* runPlanningPhase(
   prompt: string,
   session: AgentSession,
-  modelConfig?: { apiKey?: string; baseUrl?: string; model?: string }
+  modelConfig?: { apiKey?: string; baseUrl?: string; model?: string },
+  language?: string
 ): AsyncGenerator<AgentMessage> {
   const agent = getAgent(modelConfig);
 
   for await (const message of agent.plan(prompt, {
     sessionId: session.id,
     abortController: session.abortController,
+    language,
   })) {
     // Intercept plan messages and save to global store
     if (message.type === 'plan' && message.plan) {
@@ -176,7 +178,8 @@ export async function* runExecutionPhase(
   modelConfig?: { apiKey?: string; baseUrl?: string; model?: string },
   sandboxConfig?: SandboxConfig,
   skillsConfig?: SkillsConfig,
-  mcpConfig?: McpConfig
+  mcpConfig?: McpConfig,
+  language?: string
 ): AsyncGenerator<AgentMessage> {
   const agent = getAgent(modelConfig);
 
@@ -211,6 +214,7 @@ export async function* runExecutionPhase(
     sandbox: sandboxConfig,
     skillsConfig,
     mcpConfig,
+    language,
   })) {
     yield message;
   }
@@ -229,7 +233,8 @@ export async function* runAgent(
   sandboxConfig?: SandboxConfig,
   images?: ImageAttachment[],
   skillsConfig?: SkillsConfig,
-  mcpConfig?: McpConfig
+  mcpConfig?: McpConfig,
+  language?: string
 ): AsyncGenerator<AgentMessage> {
   const agent = getAgent(modelConfig);
 
@@ -253,6 +258,7 @@ export async function* runAgent(
     images,
     skillsConfig,
     mcpConfig,
+    language,
   })) {
     yield message;
   }

--- a/src-api/src/shared/types/agent.ts
+++ b/src-api/src/shared/types/agent.ts
@@ -79,6 +79,8 @@ export interface AgentRequest {
     role: 'user' | 'assistant';
     content: string;
   }>;
+  /** Preferred response language (e.g., en-US, zh-CN) */
+  language?: string;
   // Two-phase execution control
   phase?: 'plan' | 'execute';
   planId?: string; // Reference to approved plan

--- a/src/shared/hooks/useAgent.ts
+++ b/src/shared/hooks/useAgent.ts
@@ -39,6 +39,11 @@ function getErrorMessages() {
   );
 }
 
+function getPreferredLanguage(): string | undefined {
+  const lang = getSettings().language;
+  return lang && lang.trim() !== '' ? lang : undefined;
+}
+
 console.log(
   `[API] Environment: ${import.meta.env.PROD ? 'production' : 'development'}, Port: ${API_PORT}`
 );
@@ -1780,6 +1785,7 @@ export function useAgent(): UseAgentReturn {
           const workDir = computedSessionFolder || (await getAppDataDir());
           const sandboxConfig = getSandboxConfig();
           const skillsConfig = getSkillsConfig();
+          const language = getPreferredLanguage();
 
           const mcpConfig = getMcpConfig();
 
@@ -1798,6 +1804,7 @@ export function useAgent(): UseAgentReturn {
               images,
               skillsConfig,
               mcpConfig,
+              language,
             }),
             signal: abortController.signal,
           });
@@ -1821,6 +1828,7 @@ export function useAgent(): UseAgentReturn {
             body: JSON.stringify({
               prompt,
               modelConfig,
+              language: getPreferredLanguage(),
             }),
             signal: abortController.signal,
           }
@@ -2032,6 +2040,7 @@ export function useAgent(): UseAgentReturn {
       const sandboxConfig = getSandboxConfig();
       const skillsConfig = getSkillsConfig();
       const mcpConfig = getMcpConfig();
+      const language = getPreferredLanguage();
 
       const response = await fetchWithRetry(
         `${AGENT_SERVER_URL}/agent/execute`,
@@ -2049,6 +2058,7 @@ export function useAgent(): UseAgentReturn {
             sandboxConfig,
             skillsConfig,
             mcpConfig,
+            language,
           }),
           signal: abortController.signal,
         }


### PR DESCRIPTION
## Summary
- pass preferred language from settings through API and agent options
- inject language requirement into plan/run/execute prompts
- add language resolution fallback for missing/alias values

## Testing
- API smoke: /agent/plan, /agent/execute, /agent with en-US/zh-CN prompts

Closes #26
