### PR TITLE
fix: recreate provider instances on config change

### DIFF
--- a/src-api/src/shared/utils/config.ts
+++ b/src-api/src/shared/utils/config.ts
@@ -1,0 +1,44 @@
+/**
+ * Configuration normalization helpers
+ *
+ * Provides stable serialization for config comparison.
+ */
+
+function normalizeValue(value: unknown): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeValue(item));
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const normalized: Record<string, unknown> = {};
+    for (const key of keys) {
+      const normalizedValue = normalizeValue(obj[key]);
+      if (normalizedValue !== undefined) {
+        normalized[key] = normalizedValue;
+      }
+    }
+    return normalized;
+  }
+  return value;
+}
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeValue(value));
+}
+
+export function isDeepEqualConfig(a: unknown, b: unknown): boolean {
+  return stableStringify(a) === stableStringify(b);
+}


### PR DESCRIPTION
Fixes workany-ai/workany#29

## Summary
- Recreate agent and sandbox registry instances when config changes to avoid stale provider reuse.
- Add stable config normalization and deep-compare helper for deterministic config checks.

## Testing
- Manual: ran a temporary registry validation script to confirm same-config reuse and config-change rebuild for agent and sandbox.
