### PR TITLE
fix: add context window management to reduce token usage

### DIFF
--- a/src-api/src/shared/services/chat.ts
+++ b/src-api/src/shared/services/chat.ts
@@ -17,6 +17,10 @@ const logger = createLogger('ChatService');
 
 const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
 
+// Maximum number of conversation messages to include in API calls
+// to prevent excessive token usage. Each "turn" is a user+assistant pair.
+const MAX_CONTEXT_MESSAGES = 40; // 20 turns × 2 messages
+
 function isAnthropicModel(model: string): boolean {
   return model.startsWith('claude-') || model.includes('claude');
 }
@@ -249,7 +253,16 @@ export async function* runChat(
 
   const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
   if (conversation && conversation.length > 0) {
-    for (const msg of conversation) {
+    // Limit conversation history to prevent excessive token usage
+    const trimmedConversation = conversation.length > MAX_CONTEXT_MESSAGES
+      ? conversation.slice(-MAX_CONTEXT_MESSAGES)
+      : conversation;
+
+    if (trimmedConversation.length < conversation.length) {
+      logger.info(`[ChatService] Truncated conversation history from ${conversation.length} to ${trimmedConversation.length} messages`);
+    }
+
+    for (const msg of trimmedConversation) {
       messages.push({ role: msg.role, content: msg.content });
     }
   }


### PR DESCRIPTION
## Summary

The chat service was forwarding the entire conversation history to the LLM API with no limit, causing excessive token consumption (10-20x normal). Added `MAX_CONTEXT_MESSAGES = 40` truncation in the chat service.

## Changes

- Added `MAX_CONTEXT_MESSAGES = 40` constant in `src-api/src/shared/services/chat.ts`
- Truncate conversation history to last 40 messages before API calls
- Log when truncation occurs

## Expected Effect

Token reduction of 70-80% for long conversations.

Fixes workany-ai/workany#9