### PR TITLE
fix: correct Kimi model IDs and API endpoint to fix 400 error

### DIFF
--- a/src-api/src/config/constants.ts
+++ b/src-api/src/config/constants.ts
@@ -79,7 +79,7 @@ export const DEFAULT_AGENT_PROVIDER = 'claude';
 /** Default agent model */
 export const DEFAULT_AGENT_MODEL = 'claude-sonnet-4-20250514';
 
-export const DEFAULT_KIMI_MODEL = 'kimi-for-coding';
+export const DEFAULT_KIMI_MODEL = 'moonshot-v1-128k';
 
 // ============================================================================
 // Timeouts and Limits

--- a/src-api/src/core/agent/plugin.ts
+++ b/src-api/src/core/agent/plugin.ts
@@ -188,7 +188,7 @@ export const KIMI_CONFIG_SCHEMA = {
     baseUrl: {
       type: 'string',
       description: 'Kimi Code API base URL',
-      default: 'https://api.kimi.com/coding/v1',
+      default: 'https://api.moonshot.cn/v1',
     },
     model: {
       type: 'string',

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -119,7 +119,7 @@ export const defaultAgentRuntimes: AgentRuntimeSetting[] = [
     name: 'Kimi Code (Moonshot)',
     enabled: true,
     config: {
-      model: 'kimi-for-coding',
+      model: 'moonshot-v1-128k',
     },
   },
 ];
@@ -334,11 +334,11 @@ export const defaultProviders: AIProvider[] = [
     id: 'kimi',
     name: 'Kimi (Moonshot)',
     apiKey: '',
-    baseUrl: 'https://api.kimi.com/coding/v1',
+    baseUrl: 'https://api.moonshot.cn/v1',
     enabled: true,
-    models: ['kimi-for-coding'],
+    models: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
     icon: 'K',
-    apiKeyUrl: 'https://www.kimi.com/code/docs/en/',
+    apiKeyUrl: 'https://platform.moonshot.cn/console/api-keys',
     canDelete: true,
   },
 ];
@@ -372,6 +372,7 @@ export const customProviderModels: Record<string, string[]> = {
     'deepseek-v3-250324',
   ],
   deepseek: ['deepseek-chat', 'deepseek-coder', 'deepseek-reasoner'],
+  kimi: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
   moonshot: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
   zhipu: ['glm-4-plus', 'glm-4-flash', 'glm-4-long'],
   qwen: ['qwen-max', 'qwen-plus', 'qwen-turbo'],


### PR DESCRIPTION
## Summary

Kimi provider was configured with invalid model IDs (`kimi-for-coding`) and wrong API endpoint. Fixed to use the correct Moonshot API.

## Changes

- `src/shared/db/settings.ts`: Fixed provider baseUrl to `https://api.moonshot.cn/v1`, models to `moonshot-v1-8k/32k/128k`
- `src-api/src/config/constants.ts`: Changed `DEFAULT_KIMI_MODEL` to `moonshot-v1-128k`
- `src-api/src/core/agent/plugin.ts`: Fixed config schema default baseUrl

Fixes workany-ai/workany#22