### PR TITLE
fix: improve Claude Code binary detection to handle various install paths

### DIFF
--- a/src-api/src/app/api/health.ts
+++ b/src-api/src/app/api/health.ts
@@ -239,6 +239,8 @@ function getExtendedPath(): string {
       // yarn
       `${localAppData}\\Yarn\\bin`,
       `${appData}\\Yarn\\bin`,
+      // bun
+      `${userProfile}\\.bun\\bin`,
       // volta
       `${userProfile}\\.volta\\bin`,
       `${localAppData}\\Volta\\bin`,
@@ -284,6 +286,9 @@ function getExtendedPath(): string {
       '/opt/homebrew/bin',
       `${home}/.local/bin`,
       `${home}/.npm-global/bin`,
+      `${home}/.bun/bin`,
+      `${home}/.yarn/bin`,
+      `${home}/.pnpm-global/bin`,
       `${home}/.volta/bin`,
       `${home}/code/node/npm_global/bin`
     );
@@ -327,16 +332,39 @@ async function checkCommandInWsl(command: string): Promise<boolean> {
 }
 
 async function checkCommand(command: string): Promise<boolean> {
+  const extendedEnv = {
+    ...process.env,
+    PATH: getExtendedPath(),
+  };
+
   try {
     await execAsync(command, {
-      env: {
-        ...process.env,
-        PATH: getExtendedPath(),
-      },
+      env: extendedEnv,
       shell: isWindows ? 'cmd.exe' : '/bin/sh',
     });
     return true;
   } catch {
+    // Fallback: try login shell to pick up user's full PATH (e.g. from .bashrc, .zshrc)
+    if (!isWindows) {
+      const binaryName = command.split(' ').pop() || '';
+      try {
+        await execAsync(`bash -l -c "which ${binaryName}"`, {
+          env: extendedEnv,
+          stdio: 'pipe',
+        } as Parameters<typeof execAsync>[1]);
+        return true;
+      } catch {
+        try {
+          await execAsync(`zsh -l -c "which ${binaryName}"`, {
+            env: extendedEnv,
+            stdio: 'pipe',
+          } as Parameters<typeof execAsync>[1]);
+          return true;
+        } catch {
+          // Not found in any shell
+        }
+      }
+    }
     return false;
   }
 }

--- a/src-api/src/extensions/agent/claude/index.ts
+++ b/src-api/src/extensions/agent/claude/index.ts
@@ -327,6 +327,7 @@ function getExtendedPath(): string {
     paths.push(
       join(home, 'AppData', 'Roaming', 'npm'),
       join(home, 'AppData', 'Local', 'Programs', 'nodejs'),
+      join(home, '.bun', 'bin'),
       join(home, '.volta', 'bin'),
       'C:\\Program Files\\nodejs',
       'C:\\Program Files (x86)\\nodejs'
@@ -338,6 +339,9 @@ function getExtendedPath(): string {
       '/opt/homebrew/bin',
       `${home}/.local/bin`,
       `${home}/.npm-global/bin`,
+      `${home}/.bun/bin`,
+      `${home}/.yarn/bin`,
+      `${home}/.pnpm-global/bin`,
       `${home}/.volta/bin`,
       `${home}/code/node/npm_global/bin`
     );


### PR DESCRIPTION
## Summary

The health check and Claude agent binary detection used a limited PATH that missed global install locations like ~/.bun/bin, causing false "Claude Code is not installed" errors.

## Changes

- `src-api/src/app/api/health.ts`: Added ~/.bun/bin, ~/.yarn/bin, ~/.pnpm-global/bin to PATH search; added login shell fallback
- `src-api/src/extensions/agent/claude/index.ts`: Same PATH expansion

Fixes workany-ai/workany#12