### PR TITLE
fix: pass images as multimodal content + detect tool errors

### DIFF
--- a/src-api/src/extensions/agent/codeany/index.ts
+++ b/src-api/src/extensions/agent/codeany/index.ts
@@ -193,6 +193,17 @@ export class CodeAnyAgent extends BaseAgent {
     });
   }
 
+  private looksLikeError(output: string): boolean {
+    if (!output || output.length < 10) return false;
+    const lower = output.toLowerCase();
+    const errorPatterns = [
+      'error:', 'exception:', 'traceback', 'econnrefused',
+      'etimedout', 'enotfound', 'status_code', 'failed to',
+      'permission denied', '401', '403', '500', '502', '503',
+    ];
+    return errorPatterns.some(p => lower.includes(p)) && output.length < 500;
+  }
+
   private isUsingCustomApi(): boolean {
     return !!(this.config.baseUrl && this.config.apiKey);
   }
@@ -345,11 +356,13 @@ export class CodeAnyAgent extends BaseAgent {
     }
 
     if (msg.type === 'tool_result' && msg.result) {
+      const output = msg.result.output ?? '';
+      const isError = !!(msg.result as any).is_error || this.looksLikeError(output);
       yield {
         type: 'tool_result',
         toolUseId: msg.result.tool_use_id ?? '',
-        output: msg.result.output ?? '',
-        isError: false,
+        output,
+        isError,
       };
     }
 
@@ -385,33 +398,48 @@ export class CodeAnyAgent extends BaseAgent {
       ? { enabled: true, image: options.sandbox.image, apiEndpoint: options.sandbox.apiEndpoint || SANDBOX_API_URL }
       : undefined;
 
-    // Handle image attachments
-    let imageInstruction = '';
+    // Build image content blocks for multimodal input
+    const imageContentBlocks: Array<{ type: 'image'; source: { type: 'base64'; media_type: string; data: string } }> = [];
     if (options?.images && options.images.length > 0) {
-      const imagePaths = await saveImagesToDisk(options.images, sessionCwd);
-      if (imagePaths.length > 0) {
-        imageInstruction = `
-## MANDATORY IMAGE ANALYSIS - DO THIS FIRST
-
-The user has attached ${imagePaths.length} image file(s):
-${imagePaths.map((p, i) => `${i + 1}. ${p}`).join('\n')}
-
-**YOUR FIRST ACTION MUST BE:** Use the Read tool to view each image file listed above.
-
-**CRITICAL:** DO NOT respond until you have READ and SEEN the actual image content.
-
----
-User's request (answer this AFTER reading the images):
-`;
+      for (const image of options.images) {
+        try {
+          let base64Data = image.data;
+          if (base64Data.includes(',')) {
+            base64Data = base64Data.split(',')[1];
+          }
+          const mediaType = image.mimeType || 'image/png';
+          imageContentBlocks.push({
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: mediaType,
+              data: base64Data,
+            },
+          });
+          logger.info(`[CodeAny] Added image as multimodal content: ${mediaType}, ${Math.round(base64Data.length / 1024)}KB base64`);
+        } catch (error) {
+          logger.error(`[CodeAny] Failed to process image for multimodal:`, error);
+        }
       }
     }
 
     const conversationContext = this.formatConversationHistory(options?.conversation);
     const languageInstruction = buildLanguageInstruction(options?.language, prompt);
 
-    const enhancedPrompt = imageInstruction
-      ? imageInstruction + languageInstruction + prompt + '\n\n' + getWorkspaceInstruction(sessionCwd, sandboxOpts) + conversationContext
-      : getWorkspaceInstruction(sessionCwd, sandboxOpts) + conversationContext + languageInstruction + prompt;
+    const textPrompt = getWorkspaceInstruction(sessionCwd, sandboxOpts) + conversationContext + languageInstruction + prompt;
+
+    // Build the final prompt: multimodal content array if images present, plain string otherwise
+    let finalPrompt: string | any[];
+    if (imageContentBlocks.length > 0) {
+      // Multimodal prompt: image blocks first, then text
+      finalPrompt = [
+        ...imageContentBlocks,
+        { type: 'text', text: textPrompt },
+      ];
+      logger.info(`[CodeAny] Using multimodal prompt with ${imageContentBlocks.length} image(s)`);
+    } else {
+      finalPrompt = textPrompt;
+    }
 
     // Load MCP servers
     const userMcpServers = await loadMcpServers(options?.mcpConfig as McpConfig | undefined);
@@ -429,10 +457,11 @@ User's request (answer this AFTER reading the images):
     logger.info(`[CodeAny ${session.id}] ========== AGENT START ==========`);
     logger.info(`[CodeAny ${session.id}] Model: ${this.config.model || '(default)'}`);
     logger.info(`[CodeAny ${session.id}] Custom API: ${this.isUsingCustomApi()}`);
-    logger.info(`[CodeAny ${session.id}] Prompt length: ${enhancedPrompt.length} chars`);
+    logger.info(`[CodeAny ${session.id}] Prompt length: ${typeof finalPrompt === 'string' ? finalPrompt.length : JSON.stringify(finalPrompt).length} chars`);
+    logger.info(`[CodeAny ${session.id}] Multimodal: ${imageContentBlocks.length > 0 ? `yes (${imageContentBlocks.length} images)` : 'no'}`);
 
     try {
-      for await (const message of query({ prompt: enhancedPrompt, options: sdkOpts })) {
+      for await (const message of query({ prompt: finalPrompt, options: sdkOpts })) {
         if (session.abortController.signal.aborted) break;
         yield* this.processMessage(message, session.id, sentTextHashes, sentToolIds);
       }


### PR DESCRIPTION
## Summary

Two fixes in the CodeAny agent adapter (`src-api/src/extensions/agent/codeany/index.ts`):

### 1. Multimodal image support (fixes blurry/unreadable image recognition)

**Problem:** When users attach images, the current flow is:
1. Save image to disk as `.png`
2. Inject prompt: "Use the Read tool to view each image file"
3. Agent calls Read tool → returns `[Image file: /path (size bytes)]` (just a placeholder string!)
4. Model never sees the actual image content → can only guess what's in the image

**Root cause:** The SDK's `FileReadTool` (tools/read.ts L42-44) returns a text placeholder for image files instead of actual image data. Even if it did return image data, tool results are plain strings — they can't carry multimodal content.

**Fix:** Pass images directly as multimodal content blocks in the prompt:
```typescript
// Before: indirect file-based approach (broken)
saveImagesToDisk(images) → prompt "Read these files" → Read tool → placeholder string

// After: direct multimodal content (works)
images → [{ type: 'image', source: { type: 'base64', media_type, data } }, { type: 'text', text: prompt }]
```

The LLM provider then converts these to the appropriate API format (OpenAI `image_url` / Anthropic native image blocks).

> **Dependency:** This fix works best with [codeany-ai/open-agent-sdk-typescript#13](https://github.com/codeany-ai/open-agent-sdk-typescript/pull/13) which adds image block support to the OpenAI provider. Without that SDK fix, images will work with Anthropic API but be dropped by OpenAI-compatible endpoints.

### 2. Tool result error detection

**Problem:** Tool results always had `isError: false`, even when the output clearly indicated an error (e.g., `Error: ECONNREFUSED`, `permission denied`, `403`). This means the frontend can't distinguish successful tool calls from failed ones.

**Fix:**
- Added `looksLikeError()` heuristic that checks for common error patterns in tool output
- Also respects the SDK's `is_error` flag from the tool result

## Changes

- `src-api/src/extensions/agent/codeany/index.ts`: +53 -24 lines

## Testing

Verified the multimodal transformation chain:
```
Image (base64) → { type: 'image', source: { type: 'base64', media_type: 'image/png', data: '...' } }
             → OpenAI: { type: 'image_url', image_url: { url: 'data:image/png;base64,...', detail: 'high' } }
             → Anthropic: native image block (pass-through)
```

## Backward Compatibility

- Text-only messages (no images) use the same string prompt format as before
- `saveImagesToDisk()` function is preserved but no longer called from `run()`