### PR TITLE
feat: add context assembler and channel adapter framework

### DIFF
--- a/src-api/package.json
+++ b/src-api/package.json
@@ -21,6 +21,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@codeany/open-agent-sdk": "^0.2.1",
     "@hono/node-server": "^1.14.1",
+    "@larksuiteoapi/node-sdk": "^1.60.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "color-diff-napi": "file:stubs/color-diff-napi",
     "hono": "^4.7.10",

--- a/src-api/src/app/api/channels.ts
+++ b/src-api/src/app/api/channels.ts
@@ -1,0 +1,118 @@
+/**
+ * Channel Webhook Routes
+ *
+ * Hono routes for handling incoming webhooks from messaging platforms.
+ * Routes: /channels/:channelId/webhook
+ *
+ * Note: WebSocket-mode adapters don't use these routes — they receive
+ * events directly via the SDK and route through ChannelManager.handleIncomingMessage().
+ */
+
+import { Hono } from 'hono';
+
+import { getChannelManager } from '@/core/channel';
+import {
+  getAllChannelConversations,
+  getUnsyncedConversations,
+  markSynced,
+} from '@/shared/services/channel-store';
+
+export const channelRoutes = new Hono();
+
+channelRoutes.post('/:channelId/webhook', async (c) => {
+  const channelId = c.req.param('channelId');
+  const manager = getChannelManager();
+  const adapter = manager.getAdapter(channelId);
+
+  if (!adapter) {
+    return c.json({ error: `Unknown channel: ${channelId}` }, 404);
+  }
+
+  const headers: Record<string, string> = {};
+  c.req.raw.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const rawBody = await c.req.text();
+
+  const verified = await adapter.verifyWebhook(headers, rawBody);
+  if (!verified) {
+    return c.json({ error: 'Webhook verification failed' }, 403);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    body = rawBody;
+  }
+
+  const incoming = await adapter.parseIncoming(body, headers);
+  if (!incoming) {
+    return c.json({ ok: true, message: 'Event acknowledged but not handled' });
+  }
+
+  if (incoming.directResponse) {
+    return c.json(incoming.directResponse);
+  }
+
+  // Delegate to ChannelManager for unified processing
+  try {
+    await manager.handleIncomingMessage(adapter, incoming);
+    return c.json({ ok: true });
+  } catch (error) {
+    console.error(`[Channel:${channelId}] Webhook handler error:`, error);
+    return c.json({ error: 'Internal processing error' }, 500);
+  }
+});
+
+channelRoutes.get('/', (c) => {
+  const manager = getChannelManager();
+  const adapters = manager.getRegisteredIds();
+  const status: Record<string, { connected?: boolean }> = {};
+
+  for (const id of adapters) {
+    const adapter = manager.getAdapter(id);
+    status[id] = {
+      connected: adapter?.isConnected?.() ?? undefined,
+    };
+  }
+
+  return c.json({ channels: adapters, status });
+});
+
+channelRoutes.get('/conversations/unsynced', (c) => {
+  const conversations = getUnsyncedConversations();
+  c.header('Cache-Control', 'no-store');
+  return c.json({ conversations });
+});
+
+channelRoutes.get('/conversations/all', (c) => {
+  const all = getAllChannelConversations();
+  c.header('Cache-Control', 'no-store');
+  return c.json({
+    total: all.length,
+    conversations: all,
+  });
+});
+
+channelRoutes.get('/conversations/debug', (c) => {
+  const all = getAllChannelConversations();
+  return c.json({
+    total: all.length,
+    conversations: all.map((conv) => ({
+      id: conv.id,
+      channel: conv.channel,
+      prompt: conv.prompt.slice(0, 50),
+      messageCount: conv.messages.length,
+      synced: conv.synced,
+      version: conv.version,
+    })),
+  });
+});
+
+channelRoutes.post('/conversations/synced', async (c) => {
+  const body = await c.req.json<{ ids: string[] }>();
+  const count = markSynced(body.ids || []);
+  return c.json({ ok: true, count });
+});

--- a/src-api/src/app/api/index.ts
+++ b/src-api/src/app/api/index.ts
@@ -5,3 +5,4 @@ export { previewRoutes } from './preview.js';
 export { providersRoutes } from './providers.js';
 export { filesRoutes } from './files.js';
 export { mcpRoutes } from './mcp.js';
+export { channelRoutes } from './channels.js';

--- a/src-api/src/core/channel/index.ts
+++ b/src-api/src/core/channel/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { ChannelManager, getChannelManager } from './manager';

--- a/src-api/src/core/channel/manager.ts
+++ b/src-api/src/core/channel/manager.ts
@@ -1,0 +1,447 @@
+/**
+ * Channel Manager
+ *
+ * Central registry for channel adapters.
+ * Handles webhook dispatch, WebSocket lifecycle, and session management.
+ */
+
+import type {
+  ChannelAdapter,
+  ChannelAdapterConfig,
+  ChannelSession,
+  IncomingMessage,
+} from './types';
+import { createSession, runAgent, type AgentMessage } from '@/shared/services/agent';
+import { getProviderManager } from '@/shared/provider/manager';
+import { getConfigLoader } from '@/config/loader';
+import {
+  appendOrCreateConversation,
+  getAllChannelConversations,
+  resetChannelSession,
+} from '@/shared/services/channel-store';
+
+// ─── Slash Commands ───────────────────────────────────────────────────────
+
+interface SlashCommand {
+  name: string;
+  match: (text: string) => boolean;
+}
+
+const SLASH_COMMANDS: SlashCommand[] = [
+  { name: 'new',     match: (t) => /^\/(new|新对话)\s*$/i.test(t.trim()) },
+  { name: 'reset',   match: (t) => /^\/(reset|重置)\s*$/i.test(t.trim()) },
+  { name: 'help',    match: (t) => /^\/(help|帮助|命令)\s*$/i.test(t.trim()) },
+];
+
+export class ChannelManager {
+  private adapters = new Map<string, ChannelAdapter>();
+  private sessions = new Map<string, ChannelSession>();
+
+  /**
+   * Per-channel serial queue.
+   * Ensures messages from the same channel are processed one at a time,
+   * preventing concurrent appendOrCreateConversation calls from corrupting
+   * the conversation state (message ordering, version counter, etc.).
+   */
+  private channelQueues = new Map<string, Promise<void>>();
+
+  private enqueue(channelKey: string, fn: () => Promise<void>): void {
+    const prev = this.channelQueues.get(channelKey) ?? Promise.resolve();
+    const next = prev.then(fn, fn); // always chain, even if prev rejected
+    this.channelQueues.set(channelKey, next);
+    // Cleanup: when the chain settles and is still the latest, remove it
+    next.then(() => {
+      if (this.channelQueues.get(channelKey) === next) {
+        this.channelQueues.delete(channelKey);
+      }
+    });
+  }
+
+  async register(
+    adapter: ChannelAdapter,
+    config: ChannelAdapterConfig
+  ): Promise<void> {
+    if (!config.enabled) {
+      console.log(`[Channel] Adapter "${adapter.id}" is disabled, skipping`);
+      return;
+    }
+
+    // If an adapter with the same ID is already registered, shut it down first
+    const existing = this.adapters.get(adapter.id);
+    if (existing) {
+      console.log(`[Channel] Replacing existing adapter: ${adapter.id}`);
+      try {
+        if (existing.disconnect) await existing.disconnect();
+        await existing.shutdown();
+      } catch (err) {
+        console.error(`[Channel] Error shutting down existing ${adapter.id}:`, err);
+      }
+      this.adapters.delete(adapter.id);
+    }
+
+    await adapter.initialize(config);
+    this.adapters.set(adapter.id, adapter);
+    console.log(`[Channel] Registered adapter: ${adapter.id} (${adapter.name})`);
+
+    // If the adapter supports WebSocket mode, connect it
+    const mode = config.connectionMode || 'webhook';
+    if (mode === 'websocket' && adapter.connect) {
+      console.log(`[Channel] Starting WebSocket connection for ${adapter.id}...`);
+      await adapter.connect((msg) => this.handleIncomingMessage(adapter, msg));
+      console.log(`[Channel] WebSocket connected for ${adapter.id}`);
+    }
+  }
+
+  /**
+   * Handle an incoming message from any adapter (WebSocket or Webhook).
+   * Intercepts slash commands, then runs the agent for normal messages.
+   *
+   * Messages from the same channel are serialized via enqueue() to prevent
+   * concurrent agent runs from corrupting conversation state.
+   */
+  async handleIncomingMessage(
+    adapter: ChannelAdapter,
+    incoming: IncomingMessage
+  ): Promise<void> {
+    const channelKey = `${adapter.id}:${incoming.conversationId}`;
+
+    console.log(`[Channel] Message enqueued: ${channelKey}, content="${incoming.content.slice(0, 60)}"`);
+
+    this.enqueue(channelKey, () => this._processMessage(adapter, incoming));
+  }
+
+  /**
+   * Internal: process a single message (runs inside the per-channel serial queue).
+   */
+  private async _processMessage(
+    adapter: ChannelAdapter,
+    incoming: IncomingMessage
+  ): Promise<void> {
+    console.log(`[Channel] Processing message: content="${incoming.content.slice(0, 60)}", conversationId=${incoming.conversationId}`);
+
+    // ─── Slash command check ─────────────────────────────────────────
+    const command = SLASH_COMMANDS.find((c) => c.match(incoming.content));
+    if (command) {
+      console.log(`[Channel] Slash command intercepted: /${command.name}`);
+      await this.handleSlashCommand(adapter, incoming, command.name);
+      return;
+    }
+
+    // ─── Model config ────────────────────────────────────────────────
+    const modelConfig = this.resolveModelConfig();
+    if (!modelConfig?.apiKey) {
+      console.error('[Channel] No API key configured');
+      await this.sendTextReply(
+        adapter, incoming,
+        '⚠️ AI model not configured or API Key invalid. Please check model settings in the desktop app.',
+      );
+      return;
+    }
+
+    console.log(`[Channel] Model config: model=${modelConfig.model || '(default)'}, baseUrl=${modelConfig.baseUrl || '(default)'}`);
+
+    const channelSession = this.getOrCreateSession(adapter.id, incoming.conversationId);
+    const agentSession = createSession('execute');
+    const agentMessages: AgentMessage[] = [];
+
+    // Streaming card state
+    const supportsStreaming = !!(adapter.sendStreamingCard && adapter.updateStreamingCard && adapter.closeStreamingCard);
+    let streamingMessageId: string | null = null;
+    let streamingText = '';
+    let lastUpdateTs = 0;
+    let pendingUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+    const STREAM_MIN_DELAY_MS = 300;
+    const STREAM_MAX_DELAY_MS = 1500;
+
+    const flushStreamingUpdate = async () => {
+      if (!streamingMessageId || !streamingText) return;
+      const now = Date.now();
+      if (now - lastUpdateTs < STREAM_MIN_DELAY_MS) return;
+      lastUpdateTs = now;
+      await adapter.updateStreamingCard!(streamingMessageId, streamingText);
+    };
+
+    const scheduleStreamingUpdate = () => {
+      if (pendingUpdateTimer) return;
+      const elapsed = Date.now() - lastUpdateTs;
+      const delay = Math.max(STREAM_MIN_DELAY_MS - elapsed, 0);
+      pendingUpdateTimer = setTimeout(async () => {
+        pendingUpdateTimer = null;
+        await flushStreamingUpdate();
+      }, Math.min(delay, STREAM_MAX_DELAY_MS));
+    };
+
+    try {
+      console.log(`[Channel] Agent starting: sessionId=${agentSession.id}, historyLen=${channelSession.history.length}, streaming=${supportsStreaming}`);
+
+      const CONTENT_TYPES = new Set(['text', 'direct_answer']);
+
+      for await (const msg of runAgent(
+        incoming.content,
+        agentSession,
+        channelSession.history,
+        undefined,
+        undefined,
+        modelConfig,
+      )) {
+        agentMessages.push(msg);
+
+        // ─── Streaming: update card on each text block ──────────────
+        if (supportsStreaming && CONTENT_TYPES.has(msg.type) && (msg as any).content) {
+          const textContent = (msg as any).content as string;
+          streamingText += (streamingText ? '\n' : '') + textContent;
+
+          if (!streamingMessageId) {
+            // Create streaming card on first text
+            streamingMessageId = await adapter.sendStreamingCard!(
+              incoming.conversationId,
+              streamingText,
+            );
+            if (streamingMessageId) {
+              lastUpdateTs = Date.now();
+              console.log(`[Channel] Streaming card created: messageId=${streamingMessageId}`);
+            }
+          } else {
+            // Schedule coalesced update
+            scheduleStreamingUpdate();
+          }
+        }
+      }
+
+      // Clear any pending update timer
+      if (pendingUpdateTimer) {
+        clearTimeout(pendingUpdateTimer);
+        pendingUpdateTimer = null;
+      }
+
+      // ─── Collect assistant text ─────────────────────────────────────
+      const assistantText = agentMessages
+        .filter((m): m is AgentMessage & { content: string } =>
+          CONTENT_TYPES.has(m.type) && !!m.content
+        )
+        .map((m) => m.content)
+        .join('\n');
+
+      console.log(`[Channel] Agent completed: ${agentMessages.length} messages, text length=${assistantText.length}`);
+
+      channelSession.history.push(
+        { role: 'user', content: incoming.content },
+        { role: 'assistant', content: assistantText },
+      );
+
+      const channelKey = `${adapter.id}:${incoming.conversationId}`;
+      const storeResult = appendOrCreateConversation(channelKey, incoming.content, assistantText);
+
+      console.log(`[Channel] Conversation stored: convId=${storeResult.id}, version=${storeResult.version}, msgCount=${storeResult.messages.length}`);
+
+      // ─── Close streaming card or fallback send ─────────────────────
+      if (streamingMessageId) {
+        // Close streaming card with final formatted content
+        const response = await adapter.formatResponse(agentMessages, incoming.conversationId);
+        const closed = await adapter.closeStreamingCard!(streamingMessageId, response.content);
+        console.log(`[Channel] Streaming card closed: ${closed ? 'ok' : 'failed'}, messageId=${streamingMessageId}`);
+
+        if (!closed) {
+          // Fallback: send as new message if close failed
+          response.replyToMessageId = incoming.replyToMessageId;
+          await adapter.send(response);
+        }
+      } else {
+        // No streaming card was created — send normally
+        const response = await adapter.formatResponse(agentMessages, incoming.conversationId);
+        response.replyToMessageId = incoming.replyToMessageId;
+        console.log(`[Channel] Sending response: length=${response.content.length}`);
+
+        await adapter.send(response);
+      }
+
+    } catch (error) {
+      // Clear pending timer on error
+      if (pendingUpdateTimer) {
+        clearTimeout(pendingUpdateTimer);
+        pendingUpdateTimer = null;
+      }
+
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(`[Channel:${adapter.id}] Message handler error:`, errMsg);
+
+      // If streaming card was created but errored, close it with error message
+      if (streamingMessageId && adapter.closeStreamingCard) {
+        await adapter.closeStreamingCard(streamingMessageId, '⚠️ Message processing failed. Please try again later.').catch(() => {});
+      } else {
+        await this.sendTextReply(adapter, incoming, '⚠️ Message processing failed. Please try again later.');
+      }
+    }
+  }
+
+  /**
+   * Handle a slash command by sending a direct response without agent processing.
+   */
+  private async handleSlashCommand(
+    adapter: ChannelAdapter,
+    incoming: IncomingMessage,
+    command: string,
+  ): Promise<void> {
+    const channelKey = `${adapter.id}:${incoming.conversationId}`;
+    let replyText: string;
+
+    switch (command) {
+      case 'new': {
+        resetChannelSession(channelKey);
+        const session = this.sessions.get(channelKey);
+        if (session) session.history = [];
+        replyText = '✅ New conversation started. Previous context has been cleared.';
+        break;
+      }
+      case 'reset': {
+        resetChannelSession(channelKey);
+        const session = this.sessions.get(channelKey);
+        if (session) session.history = [];
+        replyText = '✅ Session reset. Context and short-term memory cleared.\n\nLong-term memory is preserved.';
+        break;
+      }
+      case 'help':
+        replyText = [
+          '📋 Available commands:',
+          '',
+          '/new — Start a new conversation, clear current context',
+          '/reset — Reset session (clear context + short-term memory)',
+          '/help — Show this help message',
+          '',
+          '💡 Send a message directly to start chatting.',
+        ].join('\n');
+        break;
+      default:
+        replyText = `Unknown command: /${command}`;
+    }
+
+    console.log(`[Channel:${adapter.id}] Slash command /${command}`);
+    await this.sendTextReply(adapter, incoming, replyText);
+  }
+
+  /**
+   * Send a plain text reply through the adapter.
+   */
+  private async sendTextReply(
+    adapter: ChannelAdapter,
+    incoming: IncomingMessage,
+    text: string,
+  ): Promise<void> {
+    try {
+      const response = await adapter.formatResponse(
+        [{ type: 'text', content: text }],
+        incoming.conversationId,
+      );
+      response.replyToMessageId = incoming.replyToMessageId;
+      await adapter.send(response);
+    } catch (err) {
+      console.error(`[Channel:${adapter.id}] Failed to send reply:`, err);
+    }
+  }
+
+  getAdapter(id: string): ChannelAdapter | undefined {
+    return this.adapters.get(id);
+  }
+
+  getRegisteredIds(): string[] {
+    return Array.from(this.adapters.keys());
+  }
+
+  /**
+   * Resolve model configuration from ProviderManager.
+   * The frontend syncs its settings (apiKey, baseUrl, model, apiType) to the backend
+   * via POST /providers/settings/sync, which updates ProviderManager.config.agent.config.
+   *
+   * Fallback: if ProviderManager has no config (e.g. app just restarted and frontend
+   * hasn't synced yet), read from the persisted agentConfig in config.json.
+   */
+  private resolveModelConfig(): { apiKey?: string; baseUrl?: string; model?: string; apiType?: 'anthropic-messages' | 'openai-completions' } | undefined {
+    // Primary: read from ProviderManager (in-memory, set by frontend sync)
+    const agentCfg = getProviderManager().getConfig().agent?.config as Record<string, unknown> | undefined;
+
+    const apiKey = agentCfg?.apiKey as string | undefined;
+    const baseUrl = agentCfg?.baseUrl as string | undefined;
+    const model = agentCfg?.model as string | undefined;
+    const apiType = agentCfg?.apiType as 'anthropic-messages' | 'openai-completions' | undefined;
+
+    if (apiKey) {
+      return { apiKey, baseUrl, model, apiType };
+    }
+
+    // Fallback: read persisted agentConfig from config.json
+    console.warn('[ChannelManager] No apiKey in ProviderManager config. Trying config.json fallback...');
+    try {
+      const saved = getConfigLoader().get<Record<string, unknown>>('agentConfig');
+      if (saved?.apiKey) {
+        console.log('[ChannelManager] Loaded agentConfig from config.json fallback');
+        // Also hydrate ProviderManager so subsequent calls don't need fallback
+        getProviderManager().updateFromSettings({
+          agentProvider: (getConfigLoader().get<string>('agentProvider') || 'codeany'),
+          agentConfig: saved,
+        });
+        return {
+          apiKey: saved.apiKey as string,
+          baseUrl: saved.baseUrl as string | undefined,
+          model: saved.model as string | undefined,
+          apiType: saved.apiType as 'anthropic-messages' | 'openai-completions' | undefined,
+        };
+      }
+    } catch (err) {
+      console.error('[ChannelManager] Failed to read config.json fallback:', err);
+    }
+
+    console.warn('[ChannelManager] No apiKey found in ProviderManager or config.json. Frontend may not have synced settings yet.');
+    return undefined;
+  }
+
+  getOrCreateSession(
+    channelId: string,
+    conversationId: string
+  ): ChannelSession {
+    const key = `${channelId}:${conversationId}`;
+    let session = this.sessions.get(key);
+
+    if (!session) {
+      session = {
+        channelId,
+        conversationId,
+        history: [],
+        createdAt: new Date(),
+        lastActiveAt: new Date(),
+      };
+      this.sessions.set(key, session);
+    }
+
+    session.lastActiveAt = new Date();
+    return session;
+  }
+
+  async shutdown(): Promise<void> {
+    const shutdownPromises = Array.from(this.adapters.values()).map(
+      async (adapter) => {
+        try {
+          // Disconnect WebSocket adapters first
+          if (adapter.disconnect) {
+            await adapter.disconnect();
+          }
+          await adapter.shutdown();
+        } catch (err) {
+          console.error(`[Channel] Error shutting down ${adapter.id}:`, err);
+        }
+      }
+    );
+    await Promise.all(shutdownPromises);
+    this.adapters.clear();
+    this.sessions.clear();
+    console.log('[Channel] All adapters shut down');
+  }
+}
+
+let globalManager: ChannelManager | null = null;
+
+export function getChannelManager(): ChannelManager {
+  if (!globalManager) {
+    globalManager = new ChannelManager();
+  }
+  return globalManager;
+}

--- a/src-api/src/core/channel/types.ts
+++ b/src-api/src/core/channel/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Channel Adapter Framework - Type Definitions
+ *
+ * Defines the contract for platform-specific channel adapters.
+ * Each adapter converts between a messaging platform's protocol
+ * and the internal Agent request/response format.
+ *
+ * Supports two connection modes:
+ *  - **webhook**: passive mode, receives HTTP POST from platform
+ *  - **websocket**: active mode, adapter connects to platform via long-lived WS
+ */
+
+import type { AgentMessage, ConversationMessage } from '@/core/agent/types';
+
+export type ConnectionMode = 'webhook' | 'websocket';
+
+export interface ChannelAdapterConfig {
+  enabled: boolean;
+  connectionMode?: ConnectionMode;
+  webhookSecret?: string;
+  [key: string]: unknown;
+}
+
+export interface IncomingMessage {
+  senderId: string;
+  senderName?: string;
+  content: string;
+  conversationId: string;
+  replyToMessageId?: string;
+  attachments?: Array<{
+    type: string;
+    url: string;
+    name?: string;
+  }>;
+  raw: unknown;
+  /** When set, the webhook handler returns this directly without agent processing */
+  directResponse?: unknown;
+}
+
+export interface OutgoingMessage {
+  conversationId: string;
+  content: string;
+  replyToMessageId?: string;
+  artifacts?: Array<{
+    type: string;
+    data: unknown;
+  }>;
+}
+
+export interface ChannelAdapter {
+  readonly id: string;
+  readonly name: string;
+
+  initialize(config: ChannelAdapterConfig): Promise<void>;
+
+  /** Webhook mode: verify incoming HTTP request signature */
+  verifyWebhook(headers: Record<string, string>, body: string): Promise<boolean>;
+
+  /** Webhook mode: parse incoming HTTP body into IncomingMessage */
+  parseIncoming(body: unknown, headers: Record<string, string>): Promise<IncomingMessage | null>;
+
+  formatResponse(
+    agentMessages: AgentMessage[],
+    conversationId: string
+  ): Promise<OutgoingMessage>;
+
+  send(message: OutgoingMessage): Promise<void>;
+
+  shutdown(): Promise<void>;
+
+  /**
+   * WebSocket mode: actively connect to the platform.
+   * The adapter manages its own event loop and calls `onMessage` for each incoming message.
+   * Returns once the connection is established (runs in background).
+   */
+  connect?(onMessage: (msg: IncomingMessage) => Promise<void>): Promise<void>;
+
+  /** WebSocket mode: disconnect from the platform */
+  disconnect?(): Promise<void>;
+
+  /** Whether this adapter is currently connected (WebSocket mode) */
+  isConnected?(): boolean;
+
+  // ─── Streaming Card (optional) ────────────────────────────────────
+
+  /** Create a streaming card, returns message_id for updates */
+  sendStreamingCard?(chatId: string, initialText: string): Promise<string | null>;
+
+  /** Update streaming card content */
+  updateStreamingCard?(messageId: string, text: string): Promise<boolean>;
+
+  /** Close streaming card with final content */
+  closeStreamingCard?(messageId: string, finalText: string): Promise<boolean>;
+}
+
+export interface ChannelSession {
+  channelId: string;
+  conversationId: string;
+  history: ConversationMessage[];
+  createdAt: Date;
+  lastActiveAt: Date;
+}

--- a/src-api/src/extensions/agent/codeany/index.ts
+++ b/src-api/src/extensions/agent/codeany/index.ts
@@ -235,63 +235,55 @@ export class CodeAnyAgent extends BaseAgent {
     return sdkOpts;
   }
 
-  private estimateTokenCount(text: string): number {
-    return Math.ceil(text.length / 4);
-  }
-
-  private formatConversationHistory(conversation?: ConversationMessage[]): string {
+  /**
+   * Build conversation context using the Context Assembler.
+   * Supports disk-persisted sessions and automatic compaction.
+   */
+  private async buildConversationContext(
+    sessionId: string,
+    conversation?: ConversationMessage[]
+  ): Promise<string> {
     if (!conversation || conversation.length === 0) return '';
 
-    const maxHistoryTokens = this.config.providerConfig?.maxHistoryTokens as number || 2000;
-    const minMessagesToKeep = 3;
+    try {
+      const { assembleContext } = await import('@/shared/context/assembler');
+      const maxContextTokens = (this.config.providerConfig?.maxHistoryTokens as number) || 12000;
 
-    const allFormattedMessages = conversation.map((msg) => {
+      const result = await assembleContext(sessionId, conversation, {
+        maxContextTokens,
+      });
+
+      if (result.compacted) {
+        logger.info(`[CodeAny ${sessionId}] Context compacted: ${result.estimatedTokens} tokens, ${result.recentMessageCount} recent messages kept`);
+      }
+
+      return result.context;
+    } catch (err) {
+      logger.warn(`[CodeAny ${sessionId}] Context assembly failed, falling back:`, err);
+      return this.formatConversationHistoryFallback(conversation);
+    }
+  }
+
+  /**
+   * Fallback: simple truncation (used when assembler fails).
+   */
+  private formatConversationHistoryFallback(conversation: ConversationMessage[]): string {
+    const maxTokens = (this.config.providerConfig?.maxHistoryTokens as number) || 12000;
+    const parts: string[] = [];
+    let budget = maxTokens;
+
+    for (let i = conversation.length - 1; i >= 0 && budget > 0; i--) {
+      const msg = conversation[i];
       const role = msg.role === 'user' ? 'User' : 'Assistant';
-      let messageContent = `${role}: ${msg.content}`;
-      if (msg.imagePaths && msg.imagePaths.length > 0) {
-        const imageRefs = msg.imagePaths.map((p, i) => `  - Image ${i + 1}: ${p}`).join('\n');
-        messageContent += `\n[Attached images:\n${imageRefs}\nUse Read tool to view these images if needed]`;
-      }
-      return messageContent;
-    });
-
-    const messageTokens = allFormattedMessages.map(msg => ({
-      content: msg,
-      tokens: this.estimateTokenCount(msg)
-    }));
-
-    let totalTokens = 0;
-    const selectedMessages: string[] = [];
-    const startIndex = Math.max(0, messageTokens.length - minMessagesToKeep);
-
-    for (let i = messageTokens.length - 1; i >= startIndex; i--) {
-      const message = messageTokens[i];
-      if (totalTokens + message.tokens <= maxHistoryTokens) {
-        selectedMessages.unshift(message.content);
-        totalTokens += message.tokens;
-      } else {
-        break;
-      }
+      const line = `${role}: ${msg.content}`;
+      const tokens = Math.ceil(line.length / 4);
+      if (budget - tokens < 0 && parts.length >= 2) break;
+      parts.unshift(line);
+      budget -= tokens;
     }
 
-    for (let i = startIndex - 1; i >= 0; i--) {
-      const message = messageTokens[i];
-      if (totalTokens + message.tokens <= maxHistoryTokens) {
-        selectedMessages.unshift(message.content);
-        totalTokens += message.tokens;
-      } else {
-        break;
-      }
-    }
-
-    if (selectedMessages.length === 0) return '';
-
-    const formattedMessages = selectedMessages.join('\n\n');
-    const truncationNotice = conversation.length > selectedMessages.length
-      ? `\n\n[Note: Showing ${selectedMessages.length} of ${conversation.length} messages.]`
-      : '';
-
-    return `## Previous Conversation Context\n\n${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
+    if (parts.length === 0) return '';
+    return `## Previous Conversation Context\n\n${parts.join('\n\n')}\n\n---\n## Current Request\n`;
   }
 
   private sanitizeText(text: string): string {
@@ -406,7 +398,9 @@ User's request (answer this AFTER reading the images):
       }
     }
 
-    const conversationContext = this.formatConversationHistory(options?.conversation);
+    // Use taskId as persistent context key (stable across turns); fall back to session.id
+    const contextSessionId = options?.taskId || session.id;
+    const conversationContext = await this.buildConversationContext(contextSessionId, options?.conversation);
     const languageInstruction = buildLanguageInstruction(options?.language, prompt);
 
     const enhancedPrompt = imageInstruction

--- a/src-api/src/extensions/channel/feishu.ts
+++ b/src-api/src/extensions/channel/feishu.ts
@@ -1,0 +1,1000 @@
+/**
+ * Feishu (飞书) Channel Adapter
+ *
+ * Supports two connection modes:
+ *  - **websocket** (recommended): Uses @larksuiteoapi/node-sdk WSClient for
+ *    long-lived WebSocket connection. No public URL needed.
+ *  - **webhook** (legacy): Receives HTTP POST from Feishu Open Platform.
+ *
+ * Features:
+ *  - Event parsing: im.message.receive_v1 (text messages)
+ *  - Bot API message sending with tenant_access_token auto-refresh
+ *  - Feishu interactive card formatting (Markdown)
+ *  - Message deduplication (prevents retry-induced duplicates)
+ *  - Heartbeat watchdog: detects stale connections and auto-reconnects
+ *  - Message compensation: polls REST API to recover missed messages
+ */
+
+import { createHmac } from 'node:crypto';
+
+import type {
+  ChannelAdapter,
+  ChannelAdapterConfig,
+  ConnectionMode,
+  IncomingMessage,
+  OutgoingMessage,
+} from '@/core/channel/types';
+import type { AgentMessage } from '@/core/agent/types';
+
+const FEISHU_API_BASE = 'https://open.feishu.cn/open-apis';
+
+const ARTIFACT_BLOCK_RE = /```artifact:[\w-]+\s*\n[\s\S]*?```/g;
+
+// Dedup: keep message IDs for 5 minutes
+const DEDUP_TTL_MS = 5 * 60 * 1000;
+const DEDUP_CLEANUP_INTERVAL_MS = 60 * 1000;
+
+// Heartbeat watchdog: if no WS frame arrive within this window, force reconnect.
+// Feishu server sends pong frames every ~90s, so 3 minutes is a safe threshold.
+const HEARTBEAT_TIMEOUT_MS = 3 * 60 * 1000;
+const HEARTBEAT_CHECK_INTERVAL_MS = 30 * 1000;
+
+// Connection cooldown: wait this long after closing before reconnecting.
+const RECONNECT_COOLDOWN_MS = 3_000;
+
+// Message compensation: poll interval for REST API fallback
+const COMPENSATION_INTERVAL_MS = 5 * 1000;
+const COMPENSATION_WINDOW_MS = 120 * 1000;
+const COMPENSATION_IMMEDIATE_DEBOUNCE_MS = 2_000;
+
+interface FeishuConfig extends ChannelAdapterConfig {
+  appId: string;
+  appSecret: string;
+  connectionMode?: ConnectionMode;
+  verificationToken?: string;
+  encryptKey?: string;
+}
+
+interface TokenCache {
+  token: string;
+  expiresAt: number;
+}
+
+export class FeishuAdapter implements ChannelAdapter {
+  readonly id = 'feishu';
+  readonly name = 'Feishu (飞书)';
+
+  private config: FeishuConfig | null = null;
+  private tokenCache: TokenCache | null = null;
+  private connectionMode: ConnectionMode = 'websocket';
+
+  // WebSocket mode
+  private wsClient: unknown = null;
+  private larkClient: unknown = null;
+  private larkModule: typeof import('@larksuiteoapi/node-sdk') | null = null;
+  private connected = false;
+
+  // Heartbeat watchdog
+  private lastFrameTime = 0;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnecting = false;
+  private onMessageCallback: ((msg: IncomingMessage) => Promise<void>) | null = null;
+
+  // Message compensation
+  private compensationTimer: ReturnType<typeof setInterval> | null = null;
+  private compensationCursors = new Map<string, number>();
+  private lastImmediateCompensationTs = 0;
+  private immediateCompensationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Diagnostic: last send errors
+  private _lastErrors: { time: string; step: string; error: string }[] = [];
+
+  get lastErrors() { return this._lastErrors; }
+
+  private logSendError(step: string, err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Feishu] ${step}:`, msg);
+    this._lastErrors.push({
+      time: new Date().toISOString(),
+      step,
+      error: msg,
+    });
+    if (this._lastErrors.length > 10) this._lastErrors.shift();
+  }
+
+  // Message deduplication
+  private processedMessages = new Map<string, number>();
+  private dedupTimer: ReturnType<typeof setInterval> | null = null;
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────
+
+  async initialize(config: ChannelAdapterConfig): Promise<void> {
+    this.config = config as FeishuConfig;
+    this.connectionMode = this.config.connectionMode || 'websocket';
+    this.dedupTimer = setInterval(() => this.cleanupDedup(), DEDUP_CLEANUP_INTERVAL_MS);
+
+    console.log('[Feishu] Adapter initialized', {
+      mode: this.connectionMode,
+      hasAppId: !!this.config.appId,
+      hasAppSecret: !!this.config.appSecret,
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.dedupTimer) {
+      clearInterval(this.dedupTimer);
+      this.dedupTimer = null;
+    }
+    this.stopHeartbeatWatchdog();
+    this.stopCompensation();
+    await this.disconnect();
+    this.config = null;
+    this.tokenCache = null;
+    this.processedMessages.clear();
+    this.onMessageCallback = null;
+    console.log('[Feishu] Adapter shut down');
+  }
+
+  // ─── WebSocket Mode ─────────────────────────────────────────────────
+
+  async connect(onMessage: (msg: IncomingMessage) => Promise<void>): Promise<void> {
+    if (!this.config?.appId || !this.config?.appSecret) {
+      throw new Error('[Feishu] appId / appSecret not configured');
+    }
+
+    this.onMessageCallback = onMessage;
+
+    if (this.wsClient) {
+      console.log('[Feishu] Closing previous connection before reconnecting');
+      await this.disconnect();
+      console.log(`[Feishu] Waiting ${RECONNECT_COOLDOWN_MS}ms for server-side session release...`);
+      await new Promise((r) => setTimeout(r, RECONNECT_COOLDOWN_MS));
+    }
+
+    const lark = await import('@larksuiteoapi/node-sdk');
+    this.larkModule = lark;
+
+    const baseConfig = {
+      appId: this.config.appId,
+      appSecret: this.config.appSecret,
+      domain: lark.Domain.Feishu,
+    };
+
+    this.larkClient = new lark.Client(baseConfig);
+
+    const eventDispatcher = new lark.EventDispatcher({
+      encryptKey: this.config.encryptKey || '',
+    }).register({
+      'im.message.receive_v1': (data: unknown) => {
+        try {
+          const rawMsg = (data as Record<string, unknown>)?.message as Record<string, unknown> | undefined;
+          const rawMsgId = rawMsg?.message_id as string | undefined;
+
+          console.log(`[Feishu] WS event received: messageId=${rawMsgId}`);
+          const incoming = this.parseLarkEvent(data);
+
+          if (incoming) {
+            // Detach from SDK event loop so the SDK can process the next event immediately
+            setImmediate(() => {
+              console.log(`[Feishu] Dispatching message: content="${incoming.content.slice(0, 60)}", conversationId=${incoming.conversationId}`);
+              onMessage(incoming).catch(err => {
+                console.error('[Feishu] Background message handler error:', err);
+              });
+            });
+
+            this.compensationCursors.set(incoming.conversationId, Date.now());
+            this.scheduleImmediateCompensation(onMessage);
+          }
+        } catch (err) {
+          console.error('[Feishu] Error parsing WS event:', err);
+        }
+      },
+    });
+
+    const wsClient = new lark.WSClient({
+      ...baseConfig,
+      loggerLevel: lark.LoggerLevel.info,
+    });
+
+    await wsClient.start({ eventDispatcher });
+    this.attachHeartbeatMonitor(wsClient);
+    this.wsClient = wsClient;
+    this.connected = true;
+    console.log('[Feishu] WebSocket connected');
+
+    this.startHeartbeatWatchdog();
+    this.startCompensation(onMessage);
+  }
+
+  private attachHeartbeatMonitor(wsClient: unknown): void {
+    const tryAttach = (): boolean => {
+      try {
+        const wsConfig = (wsClient as Record<string, unknown>).wsConfig as {
+          getWSInstance: () => {
+            on: (event: string, cb: (...args: unknown[]) => void) => void;
+            prependListener?: (event: string, cb: (...args: unknown[]) => void) => void;
+          } | null;
+        } | undefined;
+        const wsInstance = wsConfig?.getWSInstance?.();
+        if (!wsInstance) return false;
+
+        const prependFn = (wsInstance as unknown as Record<string, (...args: unknown[]) => void>).prependListener
+          || (wsInstance as unknown as Record<string, (...args: unknown[]) => void>).on;
+        prependFn.call(wsInstance, 'message', () => {
+          this.lastFrameTime = Date.now();
+        });
+        this.lastFrameTime = Date.now();
+        console.log('[Feishu] Heartbeat monitor attached to WebSocket');
+        return true;
+      } catch (err) {
+        console.error('[Feishu] Failed to attach heartbeat monitor:', err);
+        return false;
+      }
+    };
+
+    if (!tryAttach()) {
+      let attempts = 0;
+      const maxAttempts = 30;
+      const pollTimer = setInterval(() => {
+        attempts++;
+        if (tryAttach()) {
+          clearInterval(pollTimer);
+        } else if (attempts >= maxAttempts) {
+          clearInterval(pollTimer);
+          console.warn('[Feishu] WebSocket instance not available after 15s, heartbeat monitor not attached');
+        }
+      }, 500);
+    }
+  }
+
+  private startHeartbeatWatchdog(): void {
+    this.stopHeartbeatWatchdog();
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.connected || this.reconnecting) return;
+
+      const elapsed = Date.now() - this.lastFrameTime;
+      if (this.lastFrameTime > 0 && elapsed > HEARTBEAT_TIMEOUT_MS) {
+        console.warn(`[Feishu] Heartbeat timeout: no WS frame for ${Math.round(elapsed / 1000)}s, forcing reconnect...`);
+        this.forceReconnect();
+      }
+    }, HEARTBEAT_CHECK_INTERVAL_MS);
+  }
+
+  private stopHeartbeatWatchdog(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private async forceReconnect(): Promise<void> {
+    if (this.reconnecting || !this.onMessageCallback) return;
+    this.reconnecting = true;
+
+    try {
+      console.log('[Feishu] Force reconnecting...');
+      await this.connect(this.onMessageCallback);
+      console.log('[Feishu] Force reconnect complete');
+    } catch (err) {
+      console.error('[Feishu] Force reconnect failed:', err);
+    } finally {
+      this.reconnecting = false;
+    }
+  }
+
+  // ─── Message Compensation ────────────────────────────────────────────
+
+  private startCompensation(onMessage: (msg: IncomingMessage) => Promise<void>): void {
+    this.stopCompensation();
+    console.log(`[Feishu] Starting message compensation, interval=${COMPENSATION_INTERVAL_MS}ms`);
+
+    this.compensationTimer = setInterval(async () => {
+      if (!this.connected || !this.config) return;
+
+      const chatIds = Array.from(this.compensationCursors.keys());
+      if (chatIds.length === 0) return;
+
+      for (const [chatId, lastTs] of this.compensationCursors) {
+        if (Date.now() - lastTs > COMPENSATION_WINDOW_MS) {
+          this.compensationCursors.delete(chatId);
+          continue;
+        }
+
+        try {
+          const recovered = await this.pollMissedMessages(chatId);
+          for (const msg of recovered) {
+            console.log(`[Feishu] Compensation: recovered message ${msg.replyToMessageId} in ${chatId}`);
+            onMessage(msg).catch(err => {
+              console.error('[Feishu] Compensation handler error:', err);
+            });
+          }
+        } catch (err) {
+          console.error(`[Feishu] Compensation poll failed for ${chatId}:`, err);
+        }
+      }
+    }, COMPENSATION_INTERVAL_MS);
+  }
+
+  private stopCompensation(): void {
+    if (this.compensationTimer) {
+      clearInterval(this.compensationTimer);
+      this.compensationTimer = null;
+    }
+    if (this.immediateCompensationTimer) {
+      clearTimeout(this.immediateCompensationTimer);
+      this.immediateCompensationTimer = null;
+    }
+  }
+
+  private scheduleImmediateCompensation(onMessage: (msg: IncomingMessage) => Promise<void>): void {
+    const now = Date.now();
+    if (now - this.lastImmediateCompensationTs < COMPENSATION_IMMEDIATE_DEBOUNCE_MS) return;
+
+    if (this.immediateCompensationTimer) clearTimeout(this.immediateCompensationTimer);
+
+    this.immediateCompensationTimer = setTimeout(async () => {
+      this.immediateCompensationTimer = null;
+      this.lastImmediateCompensationTs = Date.now();
+
+      if (!this.connected || !this.config) return;
+
+      for (const [chatId, lastTs] of this.compensationCursors) {
+        if (Date.now() - lastTs > COMPENSATION_WINDOW_MS) continue;
+        try {
+          const recovered = await this.pollMissedMessages(chatId);
+          for (const msg of recovered) {
+            console.log(`[Feishu] Immediate compensation: recovered message ${msg.replyToMessageId} in ${chatId}`);
+            onMessage(msg).catch(err => {
+              console.error('[Feishu] Immediate compensation handler error:', err);
+            });
+          }
+        } catch (err) {
+          console.error(`[Feishu] Immediate compensation failed for ${chatId}:`, err);
+        }
+      }
+    }, COMPENSATION_IMMEDIATE_DEBOUNCE_MS);
+  }
+
+  private async pollMissedMessages(chatId: string): Promise<IncomingMessage[]> {
+    const token = await this.getTenantAccessToken();
+
+    const url = `${FEISHU_API_BASE}/im/v1/messages?container_id_type=chat&container_id=${chatId}&page_size=10&sort_type=ByCreateTimeDesc&user_id_type=open_id`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!res.ok) {
+      console.warn(`[Feishu] REST API poll failed for ${chatId}: ${res.status}`);
+      return [];
+    }
+
+    const result = (await res.json()) as {
+      code: number;
+      msg?: string;
+      data?: {
+        items?: Array<{
+          message_id: string;
+          msg_type: string;
+          sender: {
+            sender_type: string;
+            sender_id?: { open_id?: string; user_id?: string; union_id?: string } | string;
+            id?: string;
+          };
+          body: { content: string };
+          create_time: string;
+          chat_id: string;
+        }>;
+      };
+    };
+
+    if (result.code !== 0 || !result.data?.items) {
+      return [];
+    }
+
+    const recovered: IncomingMessage[] = [];
+    const now = Date.now();
+
+    for (const item of result.data.items) {
+      try {
+        const supportedTypes = new Set(['text', 'post', 'image', 'file', 'audio', 'video', 'media', 'sticker']);
+        if (!supportedTypes.has(item.msg_type)) continue;
+        if (item.sender?.sender_type === 'app') continue;
+
+        if (this.processedMessages.has(item.message_id)) continue;
+
+        let createTime = parseInt(item.create_time, 10);
+        if (item.create_time.length <= 10) createTime *= 1000;
+        const msgAge = now - createTime;
+
+        if (msgAge > COMPENSATION_WINDOW_MS || msgAge < 0) continue;
+
+        let content = '';
+        try {
+          const parsed = JSON.parse(item.body.content);
+          switch (item.msg_type) {
+            case 'text': content = parsed.text || ''; break;
+            case 'post': content = this.parsePostContent(parsed); break;
+            case 'image': content = '[Image]'; break;
+            case 'file': content = `[File: ${parsed.file_name || 'unknown'}]`; break;
+            case 'audio': content = '[Audio]'; break;
+            case 'video': case 'media': content = '[Video]'; break;
+            case 'sticker': content = '[Sticker]'; break;
+            default: content = parsed.text || '';
+          }
+        } catch {
+          content = item.body?.content || '';
+        }
+
+        content = content.replace(/@_all\s*/g, '').replace(/@_user_\d+\s*/g, '').trim();
+        if (!content) continue;
+
+        const rawSenderId = item.sender?.sender_id;
+        let senderId: string;
+        if (typeof rawSenderId === 'string') {
+          senderId = rawSenderId;
+        } else if (rawSenderId && typeof rawSenderId === 'object') {
+          senderId = (rawSenderId as Record<string, string>).open_id
+            || (rawSenderId as Record<string, string>).user_id
+            || (rawSenderId as Record<string, string>).union_id
+            || '';
+        } else {
+          senderId = item.sender?.id || '';
+        }
+        if (!senderId) senderId = 'unknown';
+
+        this.processedMessages.set(item.message_id, Date.now());
+
+        recovered.push({
+          senderId,
+          content,
+          conversationId: chatId,
+          replyToMessageId: item.message_id,
+          raw: item,
+        });
+      } catch (itemErr) {
+        console.warn(`[Feishu] Failed to process compensation item ${item.message_id}:`, itemErr);
+      }
+    }
+
+    return recovered;
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.stopHeartbeatWatchdog();
+    this.stopCompensation();
+
+    if (this.wsClient && this.larkModule) {
+      try {
+        const ws = this.wsClient as InstanceType<typeof this.larkModule.WSClient>;
+        ws.close({ force: true });
+        console.log('[Feishu] WSClient closed (force)');
+      } catch (err) {
+        console.error('[Feishu] Error closing WSClient:', err);
+      }
+    }
+
+    this.wsClient = null;
+    this.larkClient = null;
+    this.larkModule = null;
+    this.lastFrameTime = 0;
+    console.log('[Feishu] WebSocket disconnected');
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  // ─── Parse Lark Events ───────────────────────────────────────────────
+
+  private parseLarkEvent(data: unknown): IncomingMessage | null {
+    const event = data as Record<string, unknown>;
+    const sender = event.sender as Record<string, unknown> | undefined;
+    const message = event.message as Record<string, unknown> | undefined;
+
+    if (!message) return null;
+
+    const senderType = sender?.sender_type as string;
+    if (senderType === 'app') return null;
+
+    const messageId = message.message_id as string;
+    if (messageId && this.isDuplicate(messageId)) {
+      console.log('[Feishu] Duplicate message skipped:', messageId);
+      return null;
+    }
+
+    const msgType = message.message_type as string;
+    let content = '';
+
+    switch (msgType) {
+      case 'text': {
+        try {
+          const parsed = JSON.parse(message.content as string);
+          content = parsed.text || '';
+        } catch {
+          content = (message.content as string) || '';
+        }
+        break;
+      }
+      case 'post': {
+        try {
+          const parsed = JSON.parse(message.content as string);
+          content = this.parsePostContent(parsed);
+        } catch {
+          content = '[Rich Text Message]';
+        }
+        break;
+      }
+      case 'image': content = '[Image]'; break;
+      case 'file': {
+        try {
+          const parsed = JSON.parse(message.content as string);
+          content = `[File: ${parsed.file_name || 'unknown'}]`;
+        } catch {
+          content = '[File]';
+        }
+        break;
+      }
+      case 'audio': content = '[Audio]'; break;
+      case 'video': case 'media': content = '[Video]'; break;
+      case 'sticker': content = '[Sticker]'; break;
+      case 'merge_forward': content = '[Merged and Forwarded Message]'; break;
+      default:
+        console.log('[Feishu] Unsupported message type:', msgType);
+        return null;
+    }
+
+    content = content.replace(/@_all\s*/g, '').replace(/@_user_\d+\s*/g, '').trim();
+    if (!content) return null;
+
+    const senderId = (sender?.sender_id as Record<string, string>)?.open_id || '';
+    const chatId = message.chat_id as string;
+
+    return {
+      senderId,
+      content,
+      conversationId: chatId,
+      replyToMessageId: messageId,
+      raw: data,
+    };
+  }
+
+  private parsePostContent(parsed: Record<string, unknown>): string {
+    const parts: string[] = [];
+    const locales = Object.values(parsed);
+    for (const locale of locales) {
+      if (!locale || typeof locale !== 'object') continue;
+      const loc = locale as Record<string, unknown>;
+      const title = loc.title as string;
+      if (title) parts.push(title);
+      const contentRows = loc.content as unknown[][];
+      if (!Array.isArray(contentRows)) continue;
+      for (const row of contentRows) {
+        if (!Array.isArray(row)) continue;
+        for (const element of row) {
+          const el = element as Record<string, unknown>;
+          if (el.tag === 'text' && el.text) parts.push(el.text as string);
+          else if (el.tag === 'a' && el.text) parts.push(el.text as string);
+          else if (el.tag === 'at' && el.user_name) parts.push(`@${el.user_name}`);
+          else if (el.tag === 'img') parts.push('[Image]');
+          else if (el.tag === 'media') parts.push('[Media]');
+        }
+      }
+      if (parts.length > 0) break;
+    }
+    return parts.join(' ').trim() || '[Rich Text]';
+  }
+
+  // ─── Webhook Mode ───────────────────────────────────────────────────
+
+  async verifyWebhook(headers: Record<string, string>, body: string): Promise<boolean> {
+    if (!this.config?.encryptKey) return true;
+
+    const timestamp = headers['x-lark-request-timestamp'] || '';
+    const nonce = headers['x-lark-request-nonce'] || '';
+    const signature = headers['x-lark-signature'] || '';
+
+    if (!timestamp || !nonce || !signature) return true;
+
+    const toSign = timestamp + nonce + this.config.encryptKey + body;
+    const expected = createHmac('sha256', '')
+      .update(toSign)
+      .digest('hex');
+
+    return expected === signature;
+  }
+
+  async parseIncoming(body: unknown, _headers: Record<string, string>): Promise<IncomingMessage | null> {
+    const payload = body as Record<string, unknown>;
+
+    // URL verification challenge
+    if (payload.type === 'url_verification') {
+      console.log('[Feishu] Handling url_verification challenge');
+      return {
+        senderId: '',
+        content: '',
+        conversationId: '',
+        raw: body,
+        directResponse: { challenge: payload.challenge },
+      };
+    }
+
+    if (payload.schema === '2.0') return this.parseV2Event(payload);
+    if (payload.event) return this.parseV1Event(payload);
+
+    console.log('[Feishu] Unrecognized event schema:', Object.keys(payload));
+    return null;
+  }
+
+  private parseV2Event(payload: Record<string, unknown>): IncomingMessage | null {
+    const header = payload.header as Record<string, unknown> | undefined;
+    const event = payload.event as Record<string, unknown> | undefined;
+
+    if (!header || !event) return null;
+
+    const eventType = header.event_type as string;
+
+    if (this.config?.verificationToken && header.token !== this.config.verificationToken) {
+      console.warn('[Feishu] Verification token mismatch');
+      return null;
+    }
+
+    if (eventType !== 'im.message.receive_v1') {
+      console.log('[Feishu] Skipping event type:', eventType);
+      return null;
+    }
+
+    const sender = event.sender as Record<string, unknown> | undefined;
+    const message = event.message as Record<string, unknown> | undefined;
+
+    if (!message) return null;
+
+    const senderId = (sender?.sender_id as Record<string, string>)?.open_id || '';
+    const senderType = sender?.sender_type as string;
+
+    if (senderType === 'app') {
+      console.log('[Feishu] Ignoring bot message');
+      return null;
+    }
+
+    const messageId = message.message_id as string;
+    if (messageId && this.isDuplicate(messageId)) {
+      console.log('[Feishu] Duplicate message skipped:', messageId);
+      return null;
+    }
+
+    const msgType = message.message_type as string;
+    if (msgType !== 'text') {
+      console.log('[Feishu] Unsupported message type:', msgType);
+      return null;
+    }
+
+    let content = '';
+    try {
+      const parsed = JSON.parse(message.content as string);
+      content = parsed.text || '';
+    } catch {
+      content = (message.content as string) || '';
+    }
+
+    content = content.replace(/@_all\s*/g, '').replace(/@_user_\d+\s*/g, '').trim();
+    if (!content) return null;
+
+    return {
+      senderId,
+      content,
+      conversationId: message.chat_id as string,
+      replyToMessageId: message.message_id as string,
+      raw: payload,
+    };
+  }
+
+  private parseV1Event(payload: Record<string, unknown>): IncomingMessage | null {
+    if (this.config?.verificationToken && payload.token !== this.config.verificationToken) {
+      console.warn('[Feishu] Verification token mismatch (v1)');
+      return null;
+    }
+
+    const event = payload.event as Record<string, unknown>;
+    if (!event) return null;
+
+    const msgType = event.msg_type as string;
+    if (msgType !== 'text') {
+      console.log('[Feishu] Unsupported v1 message type:', msgType);
+      return null;
+    }
+
+    const content = ((event.text_without_at_bot || event.text) as string || '').trim();
+    if (!content) return null;
+
+    return {
+      senderId: event.open_id as string,
+      content,
+      conversationId: event.open_chat_id as string,
+      replyToMessageId: event.open_message_id as string,
+      raw: payload,
+    };
+  }
+
+  // ─── Response Formatting & Sending ──────────────────────────────────
+
+  async formatResponse(agentMessages: AgentMessage[], conversationId: string): Promise<OutgoingMessage> {
+    const CONTENT_TYPES = new Set(['text', 'direct_answer']);
+    const textParts = agentMessages
+      .filter((m): m is AgentMessage & { content: string } =>
+        CONTENT_TYPES.has(m.type) && !!m.content
+      )
+      .map((m) => m.content);
+
+    if (textParts.length === 0) {
+      const errorMsgs = agentMessages.filter((m) => m.type === 'error' && (m as any).message);
+      const resultErrorMsgs = agentMessages.filter((m) => m.type === 'result' && (m as any).content === 'error');
+
+      if (errorMsgs.length > 0) {
+        const errMsg = (errorMsgs[0] as any).message as string;
+        if (errMsg.includes('__API_KEY_ERROR__')) {
+          textParts.push('⚠️ AI model not configured or API Key invalid. Please check settings in the desktop app.');
+        } else if (errMsg.includes('__CUSTOM_API_ERROR__')) {
+          textParts.push('⚠️ Custom API connection failed. Please check the API address and model configuration.');
+        } else {
+          textParts.push('⚠️ An error occurred while processing your message. Please try again later.');
+        }
+      } else if (resultErrorMsgs.length > 0) {
+        textParts.push('⚠️ AI model call failed. Please check the API type configuration in settings.');
+      }
+    }
+
+    let text = textParts.join('\n\n') || '⚠️ No response generated. Please try again.';
+    text = text.replace(ARTIFACT_BLOCK_RE, '').replace(/\n{3,}/g, '\n\n').trim();
+
+    if (!text) {
+      text = 'Done.';
+    }
+
+    console.log(`[Feishu] formatResponse: ${agentMessages.length} messages → ${text.length} chars`);
+
+    return { conversationId, content: text };
+  }
+
+  private chunkText(text: string, maxLen = 3800): string[] {
+    if (text.length <= maxLen) return [text];
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+      if (remaining.length <= maxLen) {
+        chunks.push(remaining);
+        break;
+      }
+
+      let splitAt = remaining.lastIndexOf('\n\n', maxLen);
+      if (splitAt < maxLen * 0.3) {
+        splitAt = remaining.lastIndexOf('\n', maxLen);
+      }
+      if (splitAt < maxLen * 0.3) {
+        splitAt = maxLen;
+      }
+
+      chunks.push(remaining.slice(0, splitAt).trimEnd());
+      remaining = remaining.slice(splitAt).trimStart();
+    }
+
+    return chunks;
+  }
+
+  // Internal send trace for debugging
+  private _sendTrace: { step: string; status: string; detail?: string; ts: number }[] = [];
+
+  async send(message: OutgoingMessage): Promise<void> {
+    if (!this.config) throw new Error('[Feishu] Adapter not initialized');
+
+    this._sendTrace = [];
+    const st = (step: string, status: 'ok' | 'fail', detail?: string) => {
+      this._sendTrace.push({ step, status, detail, ts: Date.now() });
+      console.log(`[Feishu:Send] ${status === 'ok' ? '✅' : '❌'} ${step}: ${detail || status}`);
+    };
+
+    const chunks = this.chunkText(message.content);
+    if (chunks.length > 1) {
+      console.log(`[Feishu] Splitting message into ${chunks.length} chunks`);
+    }
+
+    for (let ci = 0; ci < chunks.length; ci++) {
+      const chunk = chunks[ci];
+      const chunkLabel = chunks.length > 1 ? ` [${ci + 1}/${chunks.length}]` : '';
+      let sent = false;
+
+      for (let attempt = 1; attempt <= 2 && !sent; attempt++) {
+        // Strategy 1: Schema 2.0 Markdown card
+        const cardOk = await this.sendViaSDKCard(message.conversationId, chunk);
+        if (cardOk) { st(`card${chunkLabel} (attempt ${attempt})`, 'ok'); sent = true; break; }
+
+        // Strategy 2: SDK plain text
+        const textOk = await this.sendViaSDKText(message.conversationId, chunk);
+        if (textOk) { st(`text${chunkLabel} (attempt ${attempt})`, 'ok'); sent = true; break; }
+        st(`${chunkLabel} (attempt ${attempt})`, 'fail', this._lastErrors.at(-1)?.error || 'unknown');
+      }
+
+      if (!sent) {
+        // Strategy 3: REST plain text as last resort
+        try {
+          await this.sendViaREST(message.conversationId, chunk);
+          st(`REST${chunkLabel}`, 'ok');
+        } catch (err) {
+          st(`REST${chunkLabel}`, 'fail', err instanceof Error ? err.message : String(err));
+          throw err;
+        }
+      }
+    }
+  }
+
+  private async sendViaSDKCard(chatId: string, text: string): Promise<boolean> {
+    if (!this.larkClient || !this.larkModule) return false;
+
+    try {
+      const lark = this.larkModule;
+      const client = this.larkClient as InstanceType<typeof lark.Client>;
+
+      const cardContent = JSON.stringify({
+        schema: '2.0',
+        config: { wide_screen_mode: true },
+        elements: [{
+          tag: 'markdown',
+          content: text.slice(0, 4000),
+        }],
+      });
+
+      const res = await client.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'interactive',
+          content: cardContent,
+        },
+      });
+
+      if (res && typeof res.code === 'number' && res.code !== 0) {
+        this.logSendError(`SDK card code=${res.code}`, res.msg);
+        return false;
+      }
+
+      console.log('[Feishu] Sent card via SDK to', chatId);
+      return true;
+    } catch (err) {
+      this.logSendError('SDK card exception', err);
+      return false;
+    }
+  }
+
+  private async sendViaSDKText(chatId: string, text: string): Promise<boolean> {
+    if (!this.larkClient || !this.larkModule) return false;
+
+    try {
+      const lark = this.larkModule;
+      const client = this.larkClient as InstanceType<typeof lark.Client>;
+
+      const res = await client.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          content: JSON.stringify({ text }),
+          msg_type: 'text',
+        },
+      });
+
+      if (res && typeof res.code === 'number' && res.code !== 0) {
+        this.logSendError(`SDK text code=${res.code}`, res.msg);
+        return false;
+      }
+
+      console.log('[Feishu] Sent via SDK text to', chatId);
+      return true;
+    } catch (err) {
+      this.logSendError('SDK text exception', err);
+      return false;
+    }
+  }
+
+  private async sendViaREST(chatId: string, text: string): Promise<void> {
+    const token = await this.getTenantAccessToken();
+
+    const res = await fetch(
+      `${FEISHU_API_BASE}/im/v1/messages?receive_id_type=chat_id`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          receive_id: chatId,
+          msg_type: 'text',
+          content: JSON.stringify({ text }),
+        }),
+      },
+    );
+
+    if (!res.ok) {
+      const errText = await res.text();
+      this.logSendError(`REST HTTP ${res.status}`, errText.slice(0, 500));
+      throw new Error(`Feishu API error: ${res.status} - ${errText.slice(0, 200)}`);
+    }
+
+    const result = (await res.json()) as Record<string, unknown>;
+    if (result.code !== 0) {
+      this.logSendError(`REST API code=${result.code}`, result.msg);
+      throw new Error(`Feishu API code: ${result.code} msg: ${result.msg}`);
+    }
+
+    console.log('[Feishu] Sent via REST text to', chatId);
+  }
+
+  // ─── Internal Helpers ───────────────────────────────────────────────
+
+  private async getTenantAccessToken(): Promise<string> {
+    if (this.tokenCache && Date.now() < this.tokenCache.expiresAt) {
+      return this.tokenCache.token;
+    }
+
+    if (!this.config?.appId || !this.config?.appSecret) {
+      throw new Error('[Feishu] appId / appSecret not configured');
+    }
+
+    const res = await fetch(
+      `${FEISHU_API_BASE}/auth/v3/tenant_access_token/internal`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          app_id: this.config.appId,
+          app_secret: this.config.appSecret,
+        }),
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(`[Feishu] Token request failed: ${res.status}`);
+    }
+
+    const data = (await res.json()) as {
+      code: number;
+      tenant_access_token: string;
+      expire: number;
+    };
+
+    if (data.code !== 0) {
+      throw new Error(`[Feishu] Token API error code: ${data.code}`);
+    }
+
+    this.tokenCache = {
+      token: data.tenant_access_token,
+      expiresAt: Date.now() + (data.expire - 300) * 1000,
+    };
+
+    console.log('[Feishu] Tenant access token refreshed');
+    return this.tokenCache.token;
+  }
+
+  // ─── Deduplication ──────────────────────────────────────────────────
+
+  private isDuplicate(messageId: string): boolean {
+    if (this.processedMessages.has(messageId)) {
+      return true;
+    }
+    this.processedMessages.set(messageId, Date.now());
+    return false;
+  }
+
+  private cleanupDedup(): void {
+    const now = Date.now();
+    for (const [id, ts] of this.processedMessages) {
+      if (now - ts > DEDUP_TTL_MS) {
+        this.processedMessages.delete(id);
+      }
+    }
+  }
+}

--- a/src-api/src/index.ts
+++ b/src-api/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from 'hono/logger';
 
 import {
   agentRoutes,
+  channelRoutes,
   filesRoutes,
   healthRoutes,
   mcpRoutes,
@@ -34,6 +35,7 @@ app.route('/preview', previewRoutes);
 app.route('/providers', providersRoutes);
 app.route('/files', filesRoutes);
 app.route('/mcp', mcpRoutes);
+app.route('/channels', channelRoutes);
 
 // Root endpoint
 app.get('/', (c) => {

--- a/src-api/src/shared/context/assembler.ts
+++ b/src-api/src/shared/context/assembler.ts
@@ -1,0 +1,238 @@
+/**
+ * Context Assembler — builds the conversation context string for the model.
+ *
+ * Lifecycle (inspired by OpenClaw's Context Engine):
+ *   1. Ingest  — persist incoming messages to session store
+ *   2. Assemble — build context within token budget
+ *   3. Compact — if over budget, summarize older messages
+ *   4. Format  — return a structured context string
+ */
+
+import type { ConversationMessage } from '@/core/agent/types';
+import {
+  loadSession,
+  createSession as createSessionData,
+  appendMessages,
+  setCompaction,
+  getRecentMessages,
+  type SessionData,
+  type SessionMessage,
+} from './session-store';
+import {
+  compactMessages,
+  estimateTokens,
+  DEFAULT_COMPACTION_CONFIG,
+  type CompactionConfig,
+} from './compaction';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface AssemblerConfig {
+  /** Max tokens for the assembled conversation context */
+  maxContextTokens: number;
+  /** Compaction config */
+  compaction: CompactionConfig;
+}
+
+const DEFAULT_ASSEMBLER_CONFIG: AssemblerConfig = {
+  maxContextTokens: 12000,
+  compaction: DEFAULT_COMPACTION_CONFIG,
+};
+
+// ---------------------------------------------------------------------------
+// Ingest — convert frontend messages and persist
+// ---------------------------------------------------------------------------
+
+function toSessionMessages(conversation: ConversationMessage[]): SessionMessage[] {
+  return conversation.map((msg) => ({
+    role: msg.role,
+    content: msg.content,
+    timestamp: new Date().toISOString(),
+    tokenEstimate: estimateTokens(
+      msg.content + (msg.imagePaths?.join(' ') || '')
+    ),
+  }));
+}
+
+/**
+ * Ingest conversation messages into the session store.
+ * Only appends messages that are NEW (not already persisted).
+ */
+function ingestMessages(
+  sessionId: string,
+  conversation: ConversationMessage[]
+): SessionData {
+  let data = loadSession(sessionId);
+  if (!data) data = createSessionData(sessionId);
+
+  const existingCount = data.messages.length;
+  const incoming = toSessionMessages(conversation);
+
+  if (incoming.length > existingCount) {
+    const newMsgs = incoming.slice(existingCount);
+    data = appendMessages(sessionId, newMsgs);
+  }
+
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Assemble — build context within budget, compacting if needed
+// ---------------------------------------------------------------------------
+
+export interface AssembleResult {
+  /** Formatted context string to inject into the prompt */
+  context: string;
+  /** Whether compaction was triggered during this assembly */
+  compacted: boolean;
+  /** Total estimated tokens in the assembled context */
+  estimatedTokens: number;
+  /** Number of recent messages included in full */
+  recentMessageCount: number;
+}
+
+/**
+ * Assemble conversation context for the model.
+ *
+ * Steps:
+ * 1. Ingest new messages into session store
+ * 2. Check if total tokens exceed budget
+ * 3. If over budget, trigger compaction
+ * 4. Format: compaction summary (if any) + recent messages
+ */
+export async function assembleContext(
+  sessionId: string,
+  conversation: ConversationMessage[],
+  config?: Partial<AssemblerConfig>
+): Promise<AssembleResult> {
+  const cfg: AssemblerConfig = {
+    maxContextTokens: config?.maxContextTokens ?? DEFAULT_ASSEMBLER_CONFIG.maxContextTokens,
+    compaction: { ...DEFAULT_ASSEMBLER_CONFIG.compaction, ...config?.compaction },
+  };
+
+  // 1. Ingest
+  let data = ingestMessages(sessionId, conversation);
+
+  // 2. Check budget
+  const recentMsgs = getRecentMessages(data);
+  const recentTokens = recentMsgs.reduce((s, m) => s + m.tokenEstimate, 0);
+  const summaryTokens = data.compaction?.tokenEstimate ?? 0;
+  const totalTokens = recentTokens + summaryTokens;
+
+  let compacted = false;
+
+  // 3. Compact if over budget and we have enough messages
+  if (totalTokens > cfg.maxContextTokens && recentMsgs.length > cfg.compaction.keepRecentMessages) {
+    try {
+      console.log(`[Assembler] Over budget (${totalTokens} > ${cfg.maxContextTokens}), triggering compaction...`);
+
+      const summary = await compactMessages(
+        data.messages,
+        cfg.compaction.keepRecentMessages,
+        cfg.compaction
+      );
+
+      if (summary) {
+        data = setCompaction(sessionId, summary);
+        compacted = true;
+      }
+    } catch (err) {
+      console.warn('[Assembler] Compaction failed, using truncation fallback:', err);
+    }
+  }
+
+  // 4. Format
+  const context = formatContext(data, cfg.maxContextTokens);
+
+  return {
+    context,
+    compacted,
+    estimatedTokens: estimateTokens(context),
+    recentMessageCount: getRecentMessages(data).length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Format — produce the final context string
+// ---------------------------------------------------------------------------
+
+function formatContext(data: SessionData, maxTokens: number): string {
+  const parts: string[] = [];
+  const recent = getRecentMessages(data);
+
+  // Add compaction summary if present
+  if (data.compaction) {
+    parts.push('## Conversation Summary (earlier context)\n');
+    parts.push(data.compaction.summary);
+    parts.push('\n\n---\n');
+  }
+
+  // Add recent messages (within budget)
+  if (recent.length > 0) {
+    parts.push('## Recent Conversation\n');
+
+    let tokenBudget = maxTokens - estimateTokens(parts.join(''));
+    const recentParts: string[] = [];
+
+    // Work backwards from most recent, stop when budget exhausted
+    for (let i = recent.length - 1; i >= 0; i--) {
+      const msg = recent[i];
+      const role = msg.role === 'user' ? 'User' : 'Assistant';
+      const line = `${role}: ${msg.content}`;
+      const lineTokens = estimateTokens(line);
+
+      if (tokenBudget - lineTokens < 0 && recentParts.length >= 2) {
+        // Budget exceeded, insert truncation notice
+        recentParts.unshift(`[... ${i + 1} earlier messages omitted ...]`);
+        break;
+      }
+
+      recentParts.unshift(line);
+      tokenBudget -= lineTokens;
+    }
+
+    parts.push(recentParts.join('\n\n'));
+  }
+
+  if (parts.length === 0) return '';
+
+  return parts.join('\n') + '\n\n---\n## Current Request\n';
+}
+
+// ---------------------------------------------------------------------------
+// Manual compact (for /compact command)
+// ---------------------------------------------------------------------------
+
+export async function manualCompact(
+  sessionId: string,
+  instructions?: string
+): Promise<{ summary: string; ok: boolean }> {
+  const data = loadSession(sessionId);
+  if (!data || data.messages.length < 3) {
+    return { summary: '', ok: false };
+  }
+
+  try {
+    const cfg = { ...DEFAULT_COMPACTION_CONFIG };
+    if (instructions) {
+      cfg.identifierInstructions = instructions;
+    }
+
+    const summary = await compactMessages(
+      data.messages,
+      cfg.keepRecentMessages,
+      cfg
+    );
+
+    if (summary) {
+      setCompaction(sessionId, summary);
+      return { summary: summary.summary, ok: true };
+    }
+  } catch (err) {
+    console.error('[Assembler] Manual compaction failed:', err);
+  }
+
+  return { summary: '', ok: false };
+}

--- a/src-api/src/shared/context/compaction.ts
+++ b/src-api/src/shared/context/compaction.ts
@@ -1,0 +1,259 @@
+/**
+ * Compaction Engine — summarizes old conversation messages.
+ *
+ * When the conversation exceeds the token budget, this module calls the
+ * model to compress older messages into a concise summary while strictly
+ * preserving all identifiers (paths, URLs, IDs, hostnames, etc.).
+ *
+ * Inspired by OpenClaw's compaction system with safeguard mode and
+ * identifier preservation.
+ */
+
+import type { SessionMessage, CompactionSummary } from './session-store';
+import { getProviderManager } from '@/shared/provider/manager';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface CompactionConfig {
+  /** Token threshold: compact when total tokens > context budget - reserveTokensFloor */
+  reserveTokensFloor: number;
+  /** How many recent messages to always keep in full (never compact) */
+  keepRecentMessages: number;
+  /** Extra instructions for identifier preservation */
+  identifierInstructions?: string;
+  /** Timeout in ms for compaction call */
+  timeoutMs: number;
+}
+
+export const DEFAULT_COMPACTION_CONFIG: CompactionConfig = {
+  reserveTokensFloor: 16000,
+  keepRecentMessages: 6,
+  identifierInstructions: '',
+  timeoutMs: 60_000,
+};
+
+// ---------------------------------------------------------------------------
+// Token estimation (simple char/4 heuristic, same as existing code)
+// ---------------------------------------------------------------------------
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// Identifier extraction
+// ---------------------------------------------------------------------------
+
+const IDENTIFIER_PATTERNS = [
+  /(?:\/[\w.-]+){2,}/g,                        // file paths: /foo/bar/baz
+  /~\/[\w./-]+/g,                               // home-relative paths
+  /https?:\/\/\S+/g,                            // URLs
+  /\b[a-zA-Z]:\\[\w\\.-]+/g,                    // Windows paths
+  /\b(?:localhost|[\w.-]+\.(?:com|cn|io|dev|app|net|org))(?::\d+)?\b/g, // hostnames
+  /\b[A-Z][A-Z0-9_]{2,}\b/g,                   // CONSTANTS / ENV_VARS
+  /\b\d{4,}\b/g,                                // numeric IDs (4+ digits)
+];
+
+export function extractIdentifiers(messages: SessionMessage[]): string[] {
+  const ids = new Set<string>();
+  for (const msg of messages) {
+    for (const pattern of IDENTIFIER_PATTERNS) {
+      const matches = msg.content.match(pattern);
+      if (matches) {
+        for (const m of matches) {
+          if (m.length >= 3 && m.length <= 200) ids.add(m);
+        }
+      }
+    }
+  }
+  return [...ids];
+}
+
+// ---------------------------------------------------------------------------
+// Compaction prompt
+// ---------------------------------------------------------------------------
+
+function buildCompactionPrompt(
+  messages: SessionMessage[],
+  identifiers: string[],
+  config: CompactionConfig
+): string {
+  const conversation = messages
+    .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+    .join('\n\n');
+
+  const idList = identifiers.length > 0
+    ? `\n\n### Identifiers to PRESERVE EXACTLY (do not paraphrase, abbreviate, or omit):\n${identifiers.map((id) => `- \`${id}\``).join('\n')}`
+    : '';
+
+  const extraInstructions = config.identifierInstructions
+    ? `\n\n### Additional preservation rules:\n${config.identifierInstructions}`
+    : '';
+
+  return `You are a conversation summarizer. Compress the following conversation into a structured summary.
+
+## Rules:
+1. Preserve ALL file paths, directory paths, project names, URLs, hostnames, port numbers, API keys, model names, and numeric IDs EXACTLY as they appear.
+2. Preserve the user's stated intent, preferences, and decisions.
+3. Preserve any ongoing task context: what has been done, what remains to do, and the current state.
+4. Preserve tool names and their results (what data was retrieved, what files were modified).
+5. Use structured sections: "## Context", "## Completed Tasks", "## Current State", "## Key Identifiers".
+6. Output ONLY the summary. No preamble, no explanation.
+7. Target length: 300-800 words.${idList}${extraInstructions}
+
+---
+## Conversation to summarize:
+
+${conversation}`;
+}
+
+// ---------------------------------------------------------------------------
+// LLM call (direct OpenAI-compatible API, no SDK overhead)
+// ---------------------------------------------------------------------------
+
+async function callLLM(prompt: string, config: CompactionConfig): Promise<string> {
+  const manager = getProviderManager();
+  const agentCfg = manager.getConfig().agent?.config as Record<string, unknown> | undefined;
+
+  const apiKey = (agentCfg?.apiKey as string)
+    || process.env.ANTHROPIC_API_KEY
+    || process.env.OPENAI_API_KEY;
+  const baseUrl = (agentCfg?.baseUrl as string)
+    || process.env.ANTHROPIC_BASE_URL
+    || process.env.OPENAI_BASE_URL
+    || 'https://api.anthropic.com';
+  const model = (agentCfg?.model as string)
+    || process.env.AGENT_MODEL
+    || 'claude-sonnet-4-20250514';
+  const apiType = (agentCfg?.apiType as string) || 'openai-completions';
+
+  if (!apiKey) {
+    throw new Error('No API key configured for compaction');
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  try {
+    const url = apiType === 'anthropic-messages'
+      ? `${baseUrl}/v1/messages`
+      : `${baseUrl}/v1/chat/completions`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    let body: string;
+
+    if (apiType === 'anthropic-messages') {
+      headers['x-api-key'] = apiKey;
+      headers['anthropic-version'] = '2023-06-01';
+      body = JSON.stringify({
+        model,
+        max_tokens: 2000,
+        messages: [{ role: 'user', content: prompt }],
+      });
+    } else {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+      body = JSON.stringify({
+        model,
+        max_tokens: 2000,
+        messages: [
+          { role: 'system', content: 'You are a precise conversation summarizer. Follow instructions exactly.' },
+          { role: 'user', content: prompt },
+        ],
+      });
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      throw new Error(`Compaction API error ${res.status}: ${errText.slice(0, 200)}`);
+    }
+
+    const json = await res.json() as Record<string, unknown>;
+
+    if (apiType === 'anthropic-messages') {
+      const content = json.content as Array<{ type: string; text?: string }>;
+      return content?.find((b) => b.type === 'text')?.text || '';
+    } else {
+      const choices = json.choices as Array<{ message?: { content?: string } }>;
+      return choices?.[0]?.message?.content || '';
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact older messages into a summary.
+ *
+ * @param messages - All conversation messages
+ * @param keepRecentCount - Number of recent messages to keep in full
+ * @param config - Compaction configuration
+ * @returns CompactionSummary or null if not enough messages to compact
+ */
+export async function compactMessages(
+  messages: SessionMessage[],
+  keepRecentCount?: number,
+  config?: Partial<CompactionConfig>
+): Promise<CompactionSummary | null> {
+  const cfg = { ...DEFAULT_COMPACTION_CONFIG, ...config };
+  const keepCount = keepRecentCount ?? cfg.keepRecentMessages;
+
+  if (messages.length <= keepCount) {
+    return null;
+  }
+
+  const cutoff = messages.length - keepCount;
+  const toCompact = messages.slice(0, cutoff);
+  const identifiers = extractIdentifiers(toCompact);
+
+  console.log(`[Compaction] Compacting ${toCompact.length} messages, keeping ${keepCount} recent`);
+  console.log(`[Compaction] Extracted ${identifiers.length} identifiers to preserve`);
+
+  const prompt = buildCompactionPrompt(toCompact, identifiers, cfg);
+  const summary = await callLLM(prompt, cfg);
+
+  if (!summary) {
+    console.warn('[Compaction] Model returned empty summary');
+    return null;
+  }
+
+  const result: CompactionSummary = {
+    summary,
+    compactedUpTo: cutoff,
+    tokenEstimate: estimateTokens(summary),
+    createdAt: new Date().toISOString(),
+    identifiers,
+  };
+
+  console.log(`[Compaction] Summary generated: ${result.tokenEstimate} tokens (from ${toCompact.reduce((s, m) => s + m.tokenEstimate, 0)} tokens)`);
+  return result;
+}
+
+/**
+ * Manual compaction with user-provided focus instructions.
+ */
+export async function compactWithInstructions(
+  messages: SessionMessage[],
+  instructions: string,
+  config?: Partial<CompactionConfig>
+): Promise<CompactionSummary | null> {
+  return compactMessages(messages, undefined, {
+    ...config,
+    identifierInstructions: instructions,
+  });
+}

--- a/src-api/src/shared/context/session-store.ts
+++ b/src-api/src/shared/context/session-store.ts
@@ -1,0 +1,150 @@
+/**
+ * Session Store — disk-persisted conversation context.
+ *
+ * Stores full conversation messages and compaction summaries per sessionId
+ * in ~/.workany/sessions/{sessionId}.json.
+ *
+ * The full message history is NEVER truncated on disk — compaction only
+ * affects what gets assembled into the model's context window.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync, statSync } from 'fs';
+import { join } from 'path';
+import { getAppDataDir } from '@/shared/utils/paths';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SessionMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  tokenEstimate: number;
+}
+
+export interface CompactionSummary {
+  summary: string;
+  compactedUpTo: number;      // index in messages[] up to which compaction covers
+  tokenEstimate: number;
+  createdAt: string;
+  identifiers: string[];      // preserved paths, IDs, URLs
+}
+
+export interface SessionData {
+  sessionId: string;
+  messages: SessionMessage[];
+  compaction: CompactionSummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function sessionsDir(): string {
+  return join(getAppDataDir(), 'sessions');
+}
+
+function sessionPath(sessionId: string): string {
+  const safe = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return join(sessionsDir(), `${safe}.json`);
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export function loadSession(sessionId: string): SessionData | null {
+  const p = sessionPath(sessionId);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8')) as SessionData;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSession(data: SessionData): void {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  data.updatedAt = new Date().toISOString();
+  writeFileSync(sessionPath(data.sessionId), JSON.stringify(data, null, 2), 'utf-8');
+}
+
+export function createSession(sessionId: string): SessionData {
+  return {
+    sessionId,
+    messages: [],
+    compaction: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Message operations
+// ---------------------------------------------------------------------------
+
+export function appendMessages(sessionId: string, msgs: SessionMessage[]): SessionData {
+  let data = loadSession(sessionId) || createSession(sessionId);
+  data.messages.push(...msgs);
+  saveSession(data);
+  return data;
+}
+
+export function setCompaction(sessionId: string, summary: CompactionSummary): SessionData {
+  let data = loadSession(sessionId);
+  if (!data) data = createSession(sessionId);
+  data.compaction = summary;
+  saveSession(data);
+  return data;
+}
+
+/**
+ * Get total estimated tokens for all messages + compaction summary.
+ */
+export function getTotalTokens(data: SessionData): number {
+  const msgTokens = data.messages.reduce((sum, m) => sum + m.tokenEstimate, 0);
+  const compTokens = data.compaction?.tokenEstimate ?? 0;
+  return msgTokens + compTokens;
+}
+
+/**
+ * Get messages that are NOT covered by the compaction summary.
+ * These are the "recent" messages that the model will see in full.
+ */
+export function getRecentMessages(data: SessionData): SessionMessage[] {
+  if (!data.compaction) return data.messages;
+  return data.messages.slice(data.compaction.compactedUpTo);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup — remove sessions older than N days
+// ---------------------------------------------------------------------------
+
+export function cleanupOldSessions(maxAgeDays: number = 7): number {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) return 0;
+
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  let removed = 0;
+
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.json')) continue;
+    const filePath = join(dir, file);
+    try {
+      const stat = statSync(filePath);
+      if (stat.mtimeMs < cutoff) {
+        unlinkSync(filePath);
+        removed++;
+      }
+    } catch { /* skip */ }
+  }
+
+  if (removed > 0) {
+    console.log(`[SessionStore] Cleaned up ${removed} old session(s)`);
+  }
+  return removed;
+}

--- a/src-api/src/shared/services/channel-store.ts
+++ b/src-api/src/shared/services/channel-store.ts
@@ -1,0 +1,222 @@
+/**
+ * Channel Conversation Store
+ *
+ * Persistent store for conversations originating from external channels.
+ * Data is kept in-memory for fast access and periodically flushed to disk
+ * (~/.workany/channel-conversations.json) so conversations survive sidecar restarts.
+ *
+ * Supports session continuity: messages from the same channel within
+ * a time window are grouped into one conversation.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getAppDataDir } from '@/shared/utils/paths';
+
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const PERSIST_DEBOUNCE_MS = 2000; // flush to disk at most every 2s
+
+export interface ChannelMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+export interface ChannelConversation {
+  id: string;
+  channel: string;
+  prompt: string;
+  messages: ChannelMessage[];
+  status: 'completed' | 'error';
+  createdAt: number;
+  updatedAt: number;
+  synced: boolean;
+  /** Increments on each new exchange so the frontend knows to re-sync */
+  version: number;
+}
+
+// ─── Persistence layer ───────────────────────────────────────────────────────
+
+interface PersistedState {
+  conversations: [string, ChannelConversation][];
+  activeConvByChannel: [string, string][];
+}
+
+function getPersistPath(): string {
+  const dir = getAppDataDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return join(dir, 'channel-conversations.json');
+}
+
+function loadFromDisk(): {
+  conversations: Map<string, ChannelConversation>;
+  activeConvByChannel: Map<string, string>;
+} {
+  const filePath = getPersistPath();
+  const convMap = new Map<string, ChannelConversation>();
+  const activeMap = new Map<string, string>();
+
+  if (!existsSync(filePath)) {
+    return { conversations: convMap, activeConvByChannel: activeMap };
+  }
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const state: PersistedState = JSON.parse(raw);
+
+    if (Array.isArray(state.conversations)) {
+      for (const [k, v] of state.conversations) {
+        convMap.set(k, v);
+      }
+    }
+    if (Array.isArray(state.activeConvByChannel)) {
+      for (const [k, v] of state.activeConvByChannel) {
+        activeMap.set(k, v);
+      }
+    }
+
+    console.log(`[ChannelStore] Restored ${convMap.size} conversations from disk`);
+  } catch (err) {
+    console.error('[ChannelStore] Failed to load persisted state, starting fresh:', err);
+  }
+
+  return { conversations: convMap, activeConvByChannel: activeMap };
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(): void {
+  if (persistTimer) return; // already scheduled
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    flushToDisk();
+  }, PERSIST_DEBOUNCE_MS);
+}
+
+function flushToDisk(): void {
+  try {
+    const state: PersistedState = {
+      conversations: Array.from(conversations.entries()),
+      activeConvByChannel: Array.from(activeConvByChannel.entries()),
+    };
+    writeFileSync(getPersistPath(), JSON.stringify(state), 'utf-8');
+  } catch (err) {
+    console.error('[ChannelStore] Failed to persist to disk:', err);
+  }
+}
+
+// ─── In-memory state (hydrated from disk on module load) ─────────────────────
+
+const { conversations: _loadedConvs, activeConvByChannel: _loadedActive } = loadFromDisk();
+const conversations = _loadedConvs;
+const activeConvByChannel = _loadedActive;
+
+// ─── Core logic ──────────────────────────────────────────────────────────────
+
+function findActiveConversation(channel: string): ChannelConversation | null {
+  const activeId = activeConvByChannel.get(channel);
+  if (!activeId) return null;
+
+  const conv = conversations.get(activeId);
+  if (!conv) {
+    activeConvByChannel.delete(channel);
+    return null;
+  }
+
+  if (Date.now() - conv.updatedAt > SESSION_TIMEOUT_MS) {
+    activeConvByChannel.delete(channel);
+    return null;
+  }
+
+  return conv;
+}
+
+/**
+ * Extract display-friendly channel name from the routing key.
+ * e.g. 'feishu:oc_abc123' → 'feishu', 'wechat' → 'wechat'
+ */
+function displayChannel(channelKey: string): string {
+  const idx = channelKey.indexOf(':');
+  return idx > 0 ? channelKey.slice(0, idx) : channelKey;
+}
+
+export function appendOrCreateConversation(
+  channel: string,
+  userMessage: string,
+  assistantReply: string
+): ChannelConversation {
+  const now = Date.now();
+  const existing = findActiveConversation(channel);
+
+  if (existing) {
+    existing.messages.push(
+      { role: 'user', content: userMessage, timestamp: now },
+      { role: 'assistant', content: assistantReply, timestamp: now + 1 },
+    );
+    existing.updatedAt = now;
+    existing.version++;
+    existing.synced = false;
+
+    console.log(`[ChannelStore] Appended to ${existing.id} (v${existing.version})`);
+    schedulePersist();
+    return existing;
+  }
+
+  const id = `ch-${now}-${Math.random().toString(36).slice(2, 6)}`;
+  const conv: ChannelConversation = {
+    id,
+    channel: displayChannel(channel),
+    prompt: userMessage,
+    messages: [
+      { role: 'user', content: userMessage, timestamp: now },
+      { role: 'assistant', content: assistantReply, timestamp: now + 1 },
+    ],
+    status: 'completed',
+    createdAt: now,
+    updatedAt: now,
+    synced: false,
+    version: 1,
+  };
+
+  conversations.set(id, conv);
+  activeConvByChannel.set(channel, id);
+
+  console.log(`[ChannelStore] Created conversation ${id} from ${channel}`);
+  schedulePersist();
+  return conv;
+}
+
+/** Force start a new conversation for a channel (used by /new command) */
+export function resetChannelSession(channel: string): void {
+  activeConvByChannel.delete(channel);
+  console.log(`[ChannelStore] Session reset for ${channel}`);
+  schedulePersist();
+}
+
+export function getUnsyncedConversations(): ChannelConversation[] {
+  return Array.from(conversations.values())
+    .filter((c) => !c.synced)
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export function getAllChannelConversations(): ChannelConversation[] {
+  return Array.from(conversations.values()).sort(
+    (a, b) => b.createdAt - a.createdAt
+  );
+}
+
+export function markSynced(ids: string[]): number {
+  let count = 0;
+  for (const id of ids) {
+    const conv = conversations.get(id);
+    if (conv) {
+      conv.synced = true;
+      count++;
+    }
+  }
+  if (count > 0) schedulePersist();
+  return count;
+}


### PR DESCRIPTION
## Summary

Two major features that extend WorkAny beyond desktop-only usage:

### 1. Context Assembler (`shared/context/`)

Replaces the simple 2K-token truncation with a proper context management system:

- **Token-budget-aware assembly** (default 12K tokens, up from 2K)
- **Automatic compaction**: when context exceeds budget, older messages are summarized via LLM with strict identifier preservation (file paths, URLs, IDs, hostnames are never paraphrased or lost)
- **Disk-persisted sessions** (`~/.workany/sessions/`): full message history is never truncated on disk — compaction only affects what the model sees
- **Graceful fallback**: if compaction fails, falls back to simple truncation

**Files:**
- `shared/context/assembler.ts` — orchestrator
- `shared/context/compaction.ts` — LLM-based summarization with identifier extraction
- `shared/context/session-store.ts` — disk persistence

### 2. Channel Adapter Framework (`core/channel/`)

Generic adapter interface for receiving messages from external IM platforms, enabling mobile access to WorkAny:

**Architecture:**
- `core/channel/types.ts` — `ChannelAdapter` interface (webhook + WebSocket modes)
- `core/channel/manager.ts` — Central registry with:
  - Per-channel message serialization queue (prevents concurrent agent runs from corrupting state)
  - Slash commands (`/new`, `/reset`, `/help`)
  - Streaming card lifecycle (create → update → close)
  - Model config resolution from ProviderManager
- `shared/services/channel-store.ts` — Persistent conversation store with 30min session timeout
- `app/api/channels.ts` — Hono routes for webhook dispatch + conversation sync APIs

**Feishu (Lark) Adapter** (`extensions/channel/feishu.ts`):
- WebSocket mode via `@larksuiteoapi/node-sdk` WSClient (no public URL needed)
- Webhook mode with HMAC signature verification
- Multi-type message parsing (text, post, image, file, audio, video, sticker, merge_forward)
- Interactive card formatting with Markdown
- Streaming cards for real-time response updates
- Message deduplication + heartbeat watchdog + auto-reconnect

### Motivation

WorkAny currently only works via the desktop UI. But users need to interact with their agent from mobile devices too — during commutes, in meetings, or away from their desk. The channel framework makes this possible by connecting WorkAny to messaging platforms that users already have on their phones.

The Feishu adapter is the first implementation. The framework is designed to be extensible — adding Slack, Discord, Telegram, or WeChat adapters follows the same `ChannelAdapter` interface.

## Changes

- 13 files changed, +2584 -48 lines
- New dependency: `@larksuiteoapi/node-sdk` (for Feishu adapter)

## Configuration

To enable the Feishu adapter, add to `~/.workany/config.json`:
```json
{
  "channels": {
    "feishu": {
      "enabled": true,
      "connectionMode": "websocket",
      "appId": "cli_xxx",
      "appSecret": "xxx"
    }
  }
}
```