### PR TITLE
feat: add context assembler with token budget and auto-compaction

### DIFF
--- a/src-api/src/extensions/agent/codeany/index.ts
+++ b/src-api/src/extensions/agent/codeany/index.ts
@@ -235,63 +235,41 @@ export class CodeAnyAgent extends BaseAgent {
     return sdkOpts;
   }
 
-  private estimateTokenCount(text: string): number {
-    return Math.ceil(text.length / 4);
-  }
-
-  private formatConversationHistory(conversation?: ConversationMessage[]): string {
+  private async buildConversationContext(
+    sessionId: string,
+    conversation?: ConversationMessage[]
+  ): Promise<string> {
     if (!conversation || conversation.length === 0) return '';
 
-    const maxHistoryTokens = this.config.providerConfig?.maxHistoryTokens as number || 2000;
-    const minMessagesToKeep = 3;
+    try {
+      const { assembleContext } = await import('@/shared/context/assembler');
+      const maxContextTokens = (this.config.providerConfig?.maxHistoryTokens as number) || 12000;
+      const result = await assembleContext(sessionId, conversation, { maxContextTokens });
+      if (result.compacted) {
+        logger.info(`[CodeAny ${sessionId}] Context compacted: ${result.estimatedTokens} tokens, ${result.recentMessageCount} recent messages kept`);
+      }
+      return result.context;
+    } catch (err) {
+      logger.warn(`[CodeAny ${sessionId}] Context assembly failed, falling back:`, err);
+      return this.formatConversationHistoryFallback(conversation);
+    }
+  }
 
-    const allFormattedMessages = conversation.map((msg) => {
+  private formatConversationHistoryFallback(conversation: ConversationMessage[]): string {
+    const maxTokens = (this.config.providerConfig?.maxHistoryTokens as number) || 12000;
+    const parts: string[] = [];
+    let budget = maxTokens;
+    for (let i = conversation.length - 1; i >= 0 && budget > 0; i--) {
+      const msg = conversation[i];
       const role = msg.role === 'user' ? 'User' : 'Assistant';
-      let messageContent = `${role}: ${msg.content}`;
-      if (msg.imagePaths && msg.imagePaths.length > 0) {
-        const imageRefs = msg.imagePaths.map((p, i) => `  - Image ${i + 1}: ${p}`).join('\n');
-        messageContent += `\n[Attached images:\n${imageRefs}\nUse Read tool to view these images if needed]`;
-      }
-      return messageContent;
-    });
-
-    const messageTokens = allFormattedMessages.map(msg => ({
-      content: msg,
-      tokens: this.estimateTokenCount(msg)
-    }));
-
-    let totalTokens = 0;
-    const selectedMessages: string[] = [];
-    const startIndex = Math.max(0, messageTokens.length - minMessagesToKeep);
-
-    for (let i = messageTokens.length - 1; i >= startIndex; i--) {
-      const message = messageTokens[i];
-      if (totalTokens + message.tokens <= maxHistoryTokens) {
-        selectedMessages.unshift(message.content);
-        totalTokens += message.tokens;
-      } else {
-        break;
-      }
+      const line = `${role}: ${msg.content}`;
+      const tokens = Math.ceil(line.length / 4);
+      if (budget - tokens < 0 && parts.length >= 2) break;
+      parts.unshift(line);
+      budget -= tokens;
     }
-
-    for (let i = startIndex - 1; i >= 0; i--) {
-      const message = messageTokens[i];
-      if (totalTokens + message.tokens <= maxHistoryTokens) {
-        selectedMessages.unshift(message.content);
-        totalTokens += message.tokens;
-      } else {
-        break;
-      }
-    }
-
-    if (selectedMessages.length === 0) return '';
-
-    const formattedMessages = selectedMessages.join('\n\n');
-    const truncationNotice = conversation.length > selectedMessages.length
-      ? `\n\n[Note: Showing ${selectedMessages.length} of ${conversation.length} messages.]`
-      : '';
-
-    return `## Previous Conversation Context\n\n${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
+    if (parts.length === 0) return '';
+    return `## Previous Conversation Context\n\n${parts.join('\n\n')}\n\n---\n## Current Request\n`;
   }
 
   private sanitizeText(text: string): string {
@@ -406,7 +384,8 @@ User's request (answer this AFTER reading the images):
       }
     }
 
-    const conversationContext = this.formatConversationHistory(options?.conversation);
+    const contextSessionId = options?.taskId || session.id;
+    const conversationContext = await this.buildConversationContext(contextSessionId, options?.conversation);
     const languageInstruction = buildLanguageInstruction(options?.language, prompt);
 
     const enhancedPrompt = imageInstruction

--- a/src-api/src/shared/context/assembler.ts
+++ b/src-api/src/shared/context/assembler.ts
@@ -1,0 +1,238 @@
+/**
+ * Context Assembler — builds the conversation context string for the model.
+ *
+ * Lifecycle (inspired by OpenClaw's Context Engine):
+ *   1. Ingest  — persist incoming messages to session store
+ *   2. Assemble — build context within token budget
+ *   3. Compact — if over budget, summarize older messages
+ *   4. Format  — return a structured context string
+ */
+
+import type { ConversationMessage } from '@/core/agent/types';
+import {
+  loadSession,
+  createSession as createSessionData,
+  appendMessages,
+  setCompaction,
+  getRecentMessages,
+  type SessionData,
+  type SessionMessage,
+} from './session-store';
+import {
+  compactMessages,
+  estimateTokens,
+  DEFAULT_COMPACTION_CONFIG,
+  type CompactionConfig,
+} from './compaction';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface AssemblerConfig {
+  /** Max tokens for the assembled conversation context */
+  maxContextTokens: number;
+  /** Compaction config */
+  compaction: CompactionConfig;
+}
+
+const DEFAULT_ASSEMBLER_CONFIG: AssemblerConfig = {
+  maxContextTokens: 12000,
+  compaction: DEFAULT_COMPACTION_CONFIG,
+};
+
+// ---------------------------------------------------------------------------
+// Ingest — convert frontend messages and persist
+// ---------------------------------------------------------------------------
+
+function toSessionMessages(conversation: ConversationMessage[]): SessionMessage[] {
+  return conversation.map((msg) => ({
+    role: msg.role,
+    content: msg.content,
+    timestamp: new Date().toISOString(),
+    tokenEstimate: estimateTokens(
+      msg.content + (msg.imagePaths?.join(' ') || '')
+    ),
+  }));
+}
+
+/**
+ * Ingest conversation messages into the session store.
+ * Only appends messages that are NEW (not already persisted).
+ */
+function ingestMessages(
+  sessionId: string,
+  conversation: ConversationMessage[]
+): SessionData {
+  let data = loadSession(sessionId);
+  if (!data) data = createSessionData(sessionId);
+
+  const existingCount = data.messages.length;
+  const incoming = toSessionMessages(conversation);
+
+  if (incoming.length > existingCount) {
+    const newMsgs = incoming.slice(existingCount);
+    data = appendMessages(sessionId, newMsgs);
+  }
+
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Assemble — build context within budget, compacting if needed
+// ---------------------------------------------------------------------------
+
+export interface AssembleResult {
+  /** Formatted context string to inject into the prompt */
+  context: string;
+  /** Whether compaction was triggered during this assembly */
+  compacted: boolean;
+  /** Total estimated tokens in the assembled context */
+  estimatedTokens: number;
+  /** Number of recent messages included in full */
+  recentMessageCount: number;
+}
+
+/**
+ * Assemble conversation context for the model.
+ *
+ * Steps:
+ * 1. Ingest new messages into session store
+ * 2. Check if total tokens exceed budget
+ * 3. If over budget, trigger compaction
+ * 4. Format: compaction summary (if any) + recent messages
+ */
+export async function assembleContext(
+  sessionId: string,
+  conversation: ConversationMessage[],
+  config?: Partial<AssemblerConfig>
+): Promise<AssembleResult> {
+  const cfg: AssemblerConfig = {
+    maxContextTokens: config?.maxContextTokens ?? DEFAULT_ASSEMBLER_CONFIG.maxContextTokens,
+    compaction: { ...DEFAULT_ASSEMBLER_CONFIG.compaction, ...config?.compaction },
+  };
+
+  // 1. Ingest
+  let data = ingestMessages(sessionId, conversation);
+
+  // 2. Check budget
+  const recentMsgs = getRecentMessages(data);
+  const recentTokens = recentMsgs.reduce((s, m) => s + m.tokenEstimate, 0);
+  const summaryTokens = data.compaction?.tokenEstimate ?? 0;
+  const totalTokens = recentTokens + summaryTokens;
+
+  let compacted = false;
+
+  // 3. Compact if over budget and we have enough messages
+  if (totalTokens > cfg.maxContextTokens && recentMsgs.length > cfg.compaction.keepRecentMessages) {
+    try {
+      console.log(`[Assembler] Over budget (${totalTokens} > ${cfg.maxContextTokens}), triggering compaction...`);
+
+      const summary = await compactMessages(
+        data.messages,
+        cfg.compaction.keepRecentMessages,
+        cfg.compaction
+      );
+
+      if (summary) {
+        data = setCompaction(sessionId, summary);
+        compacted = true;
+      }
+    } catch (err) {
+      console.warn('[Assembler] Compaction failed, using truncation fallback:', err);
+    }
+  }
+
+  // 4. Format
+  const context = formatContext(data, cfg.maxContextTokens);
+
+  return {
+    context,
+    compacted,
+    estimatedTokens: estimateTokens(context),
+    recentMessageCount: getRecentMessages(data).length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Format — produce the final context string
+// ---------------------------------------------------------------------------
+
+function formatContext(data: SessionData, maxTokens: number): string {
+  const parts: string[] = [];
+  const recent = getRecentMessages(data);
+
+  // Add compaction summary if present
+  if (data.compaction) {
+    parts.push('## Conversation Summary (earlier context)\n');
+    parts.push(data.compaction.summary);
+    parts.push('\n\n---\n');
+  }
+
+  // Add recent messages (within budget)
+  if (recent.length > 0) {
+    parts.push('## Recent Conversation\n');
+
+    let tokenBudget = maxTokens - estimateTokens(parts.join(''));
+    const recentParts: string[] = [];
+
+    // Work backwards from most recent, stop when budget exhausted
+    for (let i = recent.length - 1; i >= 0; i--) {
+      const msg = recent[i];
+      const role = msg.role === 'user' ? 'User' : 'Assistant';
+      const line = `${role}: ${msg.content}`;
+      const lineTokens = estimateTokens(line);
+
+      if (tokenBudget - lineTokens < 0 && recentParts.length >= 2) {
+        // Budget exceeded, insert truncation notice
+        recentParts.unshift(`[... ${i + 1} earlier messages omitted ...]`);
+        break;
+      }
+
+      recentParts.unshift(line);
+      tokenBudget -= lineTokens;
+    }
+
+    parts.push(recentParts.join('\n\n'));
+  }
+
+  if (parts.length === 0) return '';
+
+  return parts.join('\n') + '\n\n---\n## Current Request\n';
+}
+
+// ---------------------------------------------------------------------------
+// Manual compact (for /compact command)
+// ---------------------------------------------------------------------------
+
+export async function manualCompact(
+  sessionId: string,
+  instructions?: string
+): Promise<{ summary: string; ok: boolean }> {
+  const data = loadSession(sessionId);
+  if (!data || data.messages.length < 3) {
+    return { summary: '', ok: false };
+  }
+
+  try {
+    const cfg = { ...DEFAULT_COMPACTION_CONFIG };
+    if (instructions) {
+      cfg.identifierInstructions = instructions;
+    }
+
+    const summary = await compactMessages(
+      data.messages,
+      cfg.keepRecentMessages,
+      cfg
+    );
+
+    if (summary) {
+      setCompaction(sessionId, summary);
+      return { summary: summary.summary, ok: true };
+    }
+  } catch (err) {
+    console.error('[Assembler] Manual compaction failed:', err);
+  }
+
+  return { summary: '', ok: false };
+}

--- a/src-api/src/shared/context/compaction.ts
+++ b/src-api/src/shared/context/compaction.ts
@@ -1,0 +1,259 @@
+/**
+ * Compaction Engine — summarizes old conversation messages.
+ *
+ * When the conversation exceeds the token budget, this module calls the
+ * model to compress older messages into a concise summary while strictly
+ * preserving all identifiers (paths, URLs, IDs, hostnames, etc.).
+ *
+ * Inspired by OpenClaw's compaction system with safeguard mode and
+ * identifier preservation.
+ */
+
+import type { SessionMessage, CompactionSummary } from './session-store';
+import { getProviderManager } from '@/shared/provider/manager';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface CompactionConfig {
+  /** Token threshold: compact when total tokens > context budget - reserveTokensFloor */
+  reserveTokensFloor: number;
+  /** How many recent messages to always keep in full (never compact) */
+  keepRecentMessages: number;
+  /** Extra instructions for identifier preservation */
+  identifierInstructions?: string;
+  /** Timeout in ms for compaction call */
+  timeoutMs: number;
+}
+
+export const DEFAULT_COMPACTION_CONFIG: CompactionConfig = {
+  reserveTokensFloor: 16000,
+  keepRecentMessages: 6,
+  identifierInstructions: '',
+  timeoutMs: 60_000,
+};
+
+// ---------------------------------------------------------------------------
+// Token estimation (simple char/4 heuristic, same as existing code)
+// ---------------------------------------------------------------------------
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// Identifier extraction
+// ---------------------------------------------------------------------------
+
+const IDENTIFIER_PATTERNS = [
+  /(?:\/[\w.-]+){2,}/g,                        // file paths: /foo/bar/baz
+  /~\/[\w./-]+/g,                               // home-relative paths
+  /https?:\/\/\S+/g,                            // URLs
+  /\b[a-zA-Z]:\\[\w\\.-]+/g,                    // Windows paths
+  /\b(?:localhost|[\w.-]+\.(?:com|cn|io|dev|app|net|org))(?::\d+)?\b/g, // hostnames
+  /\b[A-Z][A-Z0-9_]{2,}\b/g,                   // CONSTANTS / ENV_VARS
+  /\b\d{4,}\b/g,                                // numeric IDs (4+ digits)
+];
+
+export function extractIdentifiers(messages: SessionMessage[]): string[] {
+  const ids = new Set<string>();
+  for (const msg of messages) {
+    for (const pattern of IDENTIFIER_PATTERNS) {
+      const matches = msg.content.match(pattern);
+      if (matches) {
+        for (const m of matches) {
+          if (m.length >= 3 && m.length <= 200) ids.add(m);
+        }
+      }
+    }
+  }
+  return [...ids];
+}
+
+// ---------------------------------------------------------------------------
+// Compaction prompt
+// ---------------------------------------------------------------------------
+
+function buildCompactionPrompt(
+  messages: SessionMessage[],
+  identifiers: string[],
+  config: CompactionConfig
+): string {
+  const conversation = messages
+    .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+    .join('\n\n');
+
+  const idList = identifiers.length > 0
+    ? `\n\n### Identifiers to PRESERVE EXACTLY (do not paraphrase, abbreviate, or omit):\n${identifiers.map((id) => `- \`${id}\``).join('\n')}`
+    : '';
+
+  const extraInstructions = config.identifierInstructions
+    ? `\n\n### Additional preservation rules:\n${config.identifierInstructions}`
+    : '';
+
+  return `You are a conversation summarizer. Compress the following conversation into a structured summary.
+
+## Rules:
+1. Preserve ALL file paths, directory paths, project names, URLs, hostnames, port numbers, API keys, model names, and numeric IDs EXACTLY as they appear.
+2. Preserve the user's stated intent, preferences, and decisions.
+3. Preserve any ongoing task context: what has been done, what remains to do, and the current state.
+4. Preserve tool names and their results (what data was retrieved, what files were modified).
+5. Use structured sections: "## Context", "## Completed Tasks", "## Current State", "## Key Identifiers".
+6. Output ONLY the summary. No preamble, no explanation.
+7. Target length: 300-800 words.${idList}${extraInstructions}
+
+---
+## Conversation to summarize:
+
+${conversation}`;
+}
+
+// ---------------------------------------------------------------------------
+// LLM call (direct OpenAI-compatible API, no SDK overhead)
+// ---------------------------------------------------------------------------
+
+async function callLLM(prompt: string, config: CompactionConfig): Promise<string> {
+  const manager = getProviderManager();
+  const agentCfg = manager.getConfig().agent?.config as Record<string, unknown> | undefined;
+
+  const apiKey = (agentCfg?.apiKey as string)
+    || process.env.ANTHROPIC_API_KEY
+    || process.env.OPENAI_API_KEY;
+  const baseUrl = (agentCfg?.baseUrl as string)
+    || process.env.ANTHROPIC_BASE_URL
+    || process.env.OPENAI_BASE_URL
+    || 'https://api.anthropic.com';
+  const model = (agentCfg?.model as string)
+    || process.env.AGENT_MODEL
+    || 'claude-sonnet-4-20250514';
+  const apiType = (agentCfg?.apiType as string) || 'openai-completions';
+
+  if (!apiKey) {
+    throw new Error('No API key configured for compaction');
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  try {
+    const url = apiType === 'anthropic-messages'
+      ? `${baseUrl}/v1/messages`
+      : `${baseUrl}/v1/chat/completions`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    let body: string;
+
+    if (apiType === 'anthropic-messages') {
+      headers['x-api-key'] = apiKey;
+      headers['anthropic-version'] = '2023-06-01';
+      body = JSON.stringify({
+        model,
+        max_tokens: 2000,
+        messages: [{ role: 'user', content: prompt }],
+      });
+    } else {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+      body = JSON.stringify({
+        model,
+        max_tokens: 2000,
+        messages: [
+          { role: 'system', content: 'You are a precise conversation summarizer. Follow instructions exactly.' },
+          { role: 'user', content: prompt },
+        ],
+      });
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      throw new Error(`Compaction API error ${res.status}: ${errText.slice(0, 200)}`);
+    }
+
+    const json = await res.json() as Record<string, unknown>;
+
+    if (apiType === 'anthropic-messages') {
+      const content = json.content as Array<{ type: string; text?: string }>;
+      return content?.find((b) => b.type === 'text')?.text || '';
+    } else {
+      const choices = json.choices as Array<{ message?: { content?: string } }>;
+      return choices?.[0]?.message?.content || '';
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact older messages into a summary.
+ *
+ * @param messages - All conversation messages
+ * @param keepRecentCount - Number of recent messages to keep in full
+ * @param config - Compaction configuration
+ * @returns CompactionSummary or null if not enough messages to compact
+ */
+export async function compactMessages(
+  messages: SessionMessage[],
+  keepRecentCount?: number,
+  config?: Partial<CompactionConfig>
+): Promise<CompactionSummary | null> {
+  const cfg = { ...DEFAULT_COMPACTION_CONFIG, ...config };
+  const keepCount = keepRecentCount ?? cfg.keepRecentMessages;
+
+  if (messages.length <= keepCount) {
+    return null;
+  }
+
+  const cutoff = messages.length - keepCount;
+  const toCompact = messages.slice(0, cutoff);
+  const identifiers = extractIdentifiers(toCompact);
+
+  console.log(`[Compaction] Compacting ${toCompact.length} messages, keeping ${keepCount} recent`);
+  console.log(`[Compaction] Extracted ${identifiers.length} identifiers to preserve`);
+
+  const prompt = buildCompactionPrompt(toCompact, identifiers, cfg);
+  const summary = await callLLM(prompt, cfg);
+
+  if (!summary) {
+    console.warn('[Compaction] Model returned empty summary');
+    return null;
+  }
+
+  const result: CompactionSummary = {
+    summary,
+    compactedUpTo: cutoff,
+    tokenEstimate: estimateTokens(summary),
+    createdAt: new Date().toISOString(),
+    identifiers,
+  };
+
+  console.log(`[Compaction] Summary generated: ${result.tokenEstimate} tokens (from ${toCompact.reduce((s, m) => s + m.tokenEstimate, 0)} tokens)`);
+  return result;
+}
+
+/**
+ * Manual compaction with user-provided focus instructions.
+ */
+export async function compactWithInstructions(
+  messages: SessionMessage[],
+  instructions: string,
+  config?: Partial<CompactionConfig>
+): Promise<CompactionSummary | null> {
+  return compactMessages(messages, undefined, {
+    ...config,
+    identifierInstructions: instructions,
+  });
+}

--- a/src-api/src/shared/context/session-store.ts
+++ b/src-api/src/shared/context/session-store.ts
@@ -1,0 +1,150 @@
+/**
+ * Session Store — disk-persisted conversation context.
+ *
+ * Stores full conversation messages and compaction summaries per sessionId
+ * in ~/.workany/sessions/{sessionId}.json.
+ *
+ * The full message history is NEVER truncated on disk — compaction only
+ * affects what gets assembled into the model's context window.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync, statSync } from 'fs';
+import { join } from 'path';
+import { getAppDataDir } from "@/shared/utils/paths";;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SessionMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  tokenEstimate: number;
+}
+
+export interface CompactionSummary {
+  summary: string;
+  compactedUpTo: number;      // index in messages[] up to which compaction covers
+  tokenEstimate: number;
+  createdAt: string;
+  identifiers: string[];      // preserved paths, IDs, URLs
+}
+
+export interface SessionData {
+  sessionId: string;
+  messages: SessionMessage[];
+  compaction: CompactionSummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function sessionsDir(): string {
+  return join(getAppDataDir(), 'sessions');
+}
+
+function sessionPath(sessionId: string): string {
+  const safe = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return join(sessionsDir(), `${safe}.json`);
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export function loadSession(sessionId: string): SessionData | null {
+  const p = sessionPath(sessionId);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8')) as SessionData;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSession(data: SessionData): void {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  data.updatedAt = new Date().toISOString();
+  writeFileSync(sessionPath(data.sessionId), JSON.stringify(data, null, 2), 'utf-8');
+}
+
+export function createSession(sessionId: string): SessionData {
+  return {
+    sessionId,
+    messages: [],
+    compaction: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Message operations
+// ---------------------------------------------------------------------------
+
+export function appendMessages(sessionId: string, msgs: SessionMessage[]): SessionData {
+  let data = loadSession(sessionId) || createSession(sessionId);
+  data.messages.push(...msgs);
+  saveSession(data);
+  return data;
+}
+
+export function setCompaction(sessionId: string, summary: CompactionSummary): SessionData {
+  let data = loadSession(sessionId);
+  if (!data) data = createSession(sessionId);
+  data.compaction = summary;
+  saveSession(data);
+  return data;
+}
+
+/**
+ * Get total estimated tokens for all messages + compaction summary.
+ */
+export function getTotalTokens(data: SessionData): number {
+  const msgTokens = data.messages.reduce((sum, m) => sum + m.tokenEstimate, 0);
+  const compTokens = data.compaction?.tokenEstimate ?? 0;
+  return msgTokens + compTokens;
+}
+
+/**
+ * Get messages that are NOT covered by the compaction summary.
+ * These are the "recent" messages that the model will see in full.
+ */
+export function getRecentMessages(data: SessionData): SessionMessage[] {
+  if (!data.compaction) return data.messages;
+  return data.messages.slice(data.compaction.compactedUpTo);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup — remove sessions older than N days
+// ---------------------------------------------------------------------------
+
+export function cleanupOldSessions(maxAgeDays: number = 7): number {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) return 0;
+
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  let removed = 0;
+
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.json')) continue;
+    const filePath = join(dir, file);
+    try {
+      const stat = statSync(filePath);
+      if (stat.mtimeMs < cutoff) {
+        unlinkSync(filePath);
+        removed++;
+      }
+    } catch { /* skip */ }
+  }
+
+  if (removed > 0) {
+    console.log(`[SessionStore] Cleaned up ${removed} old session(s)`);
+  }
+  return removed;
+}


### PR DESCRIPTION
Replaces the simple 2K-token conversation truncation with a proper context management system:

- **Token-budget-aware assembly** (12K tokens default, up from 2K)
- **Auto-compaction**: older messages summarized via LLM with strict identifier preservation (paths, URLs, IDs never lost)
- **Disk-persisted sessions** (`~/.workany/sessions/`): full history on disk, compaction only affects model context
- **Graceful fallback**: if compaction fails, falls back to simple truncation

**Files:** `shared/context/assembler.ts`, `compaction.ts`, `session-store.ts` + codeany adapter integration