### PR TITLE
fix: point star history chart to working service

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 
 ## ⭐️ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=workany-ai/workany&type=Timeline)](https://star-history.com/#workany-ai/workany&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=workany-ai/workany&type=Timeline)](https://star-history.dera.page/#workany-ai/workany&Timeline)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken and never renders because GitHub restricts stargazer API access. This change updates the chart image and link to use star-history.dera.page, which sources the same data through a working endpoint that requires no API token. Many large projects already rely on this service, so it should be reliable for the long term.